### PR TITLE
Add daily volume reset timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ dot doctor
 - `dot init`, `dot install`, `dot stow`, and `dot update` configure the global `core.hooksPath` and enable `git-workflow-watch.timer`
 - `dot doctor` verifies the hooks path, watchlist file, timer state, and active Waybar workflow-failures module wiring
 
+## Daily volume reset
+
+- Public dotfiles provide `daily-volume-zero.timer`, a user systemd timer that runs at 5am local time
+- The timer runs `daily-volume-zero`, which sends a 10-second desktop notification, clears default sink mute, then sets the default PipeWire/WirePlumber sink volume to `0%`
+- `dot init`, `dot install`, `dot stow`, and `dot update` enable the timer; use `systemctl --user disable --now daily-volume-zero.timer` to opt out
+
 ## Environment options
 
 - `DOTFILES_PUBLIC_DIR` - public dotfiles path (default `~/.config/dotfiles`)
@@ -88,6 +94,7 @@ dot doctor
 - `DOT_WORKFLOW_WATCH_HOOKS_PATH` - global git hooks path for workflow watch (default `~/.config/git/workflow-watch-hooks`)
 - `DOT_WORKFLOW_WATCH_REPOS_FILE` - watched repo list file (default `$DOTFILES_PRIVATE_DIR/.git-workflow-watch-repos`)
 - `DOT_WORKFLOW_WATCH_TIMER_UNIT` - workflow polling timer unit name (default `git-workflow-watch.timer`)
+- `DOT_DAILY_VOLUME_ZERO_TIMER_UNIT` - 5am volume reset timer unit name (default `daily-volume-zero.timer`)
 - `DOT_AUTO_CD` - zsh wrapper auto-cd to first repo with changes after `dot diff`; otherwise restore original dir (failed diff falls back to `~/.config/dotfiles`) (`1|0`, default `1`)
 - `DOT_AGENTS_SYNC_SOURCE` - AGENTS file to mirror (default `~/.opencode/AGENTS.md`)
 - `DOT_AGENTS_SYNC_RULE_FILE` - Cursor rule output path (default `$DOTFILES_PRIVATE_DIR/agents/.cursor/rules/global-agents.mdc`, else `~/.cursor/rules/global-agents.mdc`)

--- a/scripts/.local/bin/daily-volume-zero
+++ b/scripts/.local/bin/daily-volume-zero
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Notify shortly before setting the default audio sink to 0% volume.
+set -euo pipefail
+
+DELAY_SECONDS=10
+DRY_RUN=0
+
+usage() {
+  printf 'Usage: daily-volume-zero [--delay-seconds <seconds>] [--dry-run]\n'
+}
+
+die() {
+  printf 'daily-volume-zero: %s\n' "$1" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --delay-seconds)
+      [[ $# -ge 2 ]] || die '--delay-seconds requires a value'
+      DELAY_SECONDS="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+if ! [[ "$DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  die '--delay-seconds must be a non-negative integer'
+fi
+
+if command -v notify-send >/dev/null 2>&1; then
+  notify-send \
+    -u normal \
+    -t "$((DELAY_SECONDS * 1000))" \
+    'Daily volume reset' \
+    "System volume will be set to 0% in ${DELAY_SECONDS} seconds." \
+    >/dev/null 2>&1 || true
+fi
+
+sleep "$DELAY_SECONDS"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf 'Would set @DEFAULT_AUDIO_SINK@ volume to 0%% and clear mute.\n'
+  exit 0
+fi
+
+command -v wpctl >/dev/null 2>&1 || die 'wpctl is required to control PipeWire/WirePlumber volume'
+
+wpctl set-mute @DEFAULT_AUDIO_SINK@ 0
+wpctl set-volume @DEFAULT_AUDIO_SINK@ 0%

--- a/scripts/.local/bin/dot
+++ b/scripts/.local/bin/dot
@@ -25,6 +25,7 @@ DOT_WORKFLOW_WATCH_REPOS_FILE="${DOT_WORKFLOW_WATCH_REPOS_FILE:-$PRIVATE_DOTFILE
 DOT_WORKFLOW_WATCH_TIMER_UNIT="${DOT_WORKFLOW_WATCH_TIMER_UNIT:-git-workflow-watch.timer}"
 DOT_BROWSER_FREEZE_TIMER_UNIT="${DOT_BROWSER_FREEZE_TIMER_UNIT:-browser-freeze-snapshot.timer}"
 DOT_DOCTOR_STARTUP_TIMER_UNIT="${DOT_DOCTOR_STARTUP_TIMER_UNIT:-dot-doctor-startup.timer}"
+DOT_DAILY_VOLUME_ZERO_TIMER_UNIT="${DOT_DAILY_VOLUME_ZERO_TIMER_UNIT:-daily-volume-zero.timer}"
 
 OMARCHY_REPO_BASE="${OMARCHY_REPO_BASE_DIR:-$HOME/.config}"
 OMARCHY_DIFF_REPOS=(hypr waybar bootstrap ghostty uwsm)
@@ -1463,6 +1464,22 @@ configure_workflow_watch() {
   fi
 }
 
+configure_daily_volume_zero() {
+  log_section 'Configure daily volume reset'
+
+  if ! has_cmd systemctl; then
+    log_warn 'Skipping daily volume reset timer enable (systemctl not found)'
+    return 0
+  fi
+
+  systemctl --user daemon-reload >/dev/null 2>&1 || true
+  if systemctl --user enable --now "$DOT_DAILY_VOLUME_ZERO_TIMER_UNIT" >/dev/null 2>&1; then
+    log_info "Enabled daily volume reset timer: $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+  else
+    log_warn "Could not enable daily volume reset timer: $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+  fi
+}
+
 # Mirror AGENTS.md into a Cursor user rule (.mdc with alwaysApply) so it is always-on context.
 # Default output: private agents package at agents/.cursor/rules/global-agents.mdc (stows into ~/.cursor/rules/).
 run_agents_sync() {
@@ -2582,6 +2599,7 @@ cmd_init() {
   fi
   install_public_dotfiles
   configure_workflow_watch
+  configure_daily_volume_zero
 
   if can_use_private; then
     install_private_dotfiles
@@ -2634,6 +2652,7 @@ cmd_update() {
   log_section 'Stow public dotfiles'
   stow_public_dotfiles
   configure_workflow_watch
+  configure_daily_volume_zero
 
   if can_use_private; then
     log_section 'Stow private dotfiles'
@@ -2665,6 +2684,7 @@ cmd_stow() {
   log_section 'Stow workflow'
   stow_public_dotfiles
   configure_workflow_watch
+  configure_daily_volume_zero
 
   if can_use_private; then
     stow_private_dotfiles
@@ -2681,6 +2701,7 @@ cmd_install() {
   log_section 'Install workflow'
   install_public_dotfiles
   configure_workflow_watch
+  configure_daily_volume_zero
 
   if can_use_private; then
     install_private_dotfiles
@@ -2977,6 +2998,7 @@ cmd_doctor() {
   optional_cmd gh 'branch discovery + authenticated clone convenience'
   optional_cmd gum 'interactive init questionnaire'
   optional_cmd notify-send 'desktop workflow notifications'
+  optional_cmd wpctl 'daily 5am volume reset on PipeWire/WirePlumber'
 
   if has_cmd gh; then
     if gh auth status >/dev/null 2>&1; then
@@ -3232,6 +3254,49 @@ cmd_doctor() {
     fi
   else
     doctor_warn 'Skipping doctor startup timer checks (systemctl not found)'
+  fi
+
+  doctor_log_section 'Daily volume reset'
+  local daily_volume_zero_script="$HOME/.local/bin/daily-volume-zero"
+  local daily_volume_zero_systemd_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  local daily_volume_zero_service_unit_path="$daily_volume_zero_systemd_dir/daily-volume-zero.service"
+  local daily_volume_zero_timer_unit_path="$daily_volume_zero_systemd_dir/$DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+
+  if [[ -x "$daily_volume_zero_script" ]]; then
+    log_info "Daily volume reset script found: $(display_path "$daily_volume_zero_script")"
+  else
+    doctor_warn "Daily volume reset script missing or not executable: $(display_path "$daily_volume_zero_script")"
+  fi
+
+  if [[ -f "$daily_volume_zero_service_unit_path" ]]; then
+    log_info "Daily volume reset service unit file found: $(display_path "$daily_volume_zero_service_unit_path")"
+  else
+    doctor_warn "Daily volume reset service unit file missing: $(display_path "$daily_volume_zero_service_unit_path")"
+    doctor_warn 'Run dot stow (or dot install) to link systemd user units'
+  fi
+
+  if [[ -f "$daily_volume_zero_timer_unit_path" ]]; then
+    log_info "Daily volume reset timer unit file found: $(display_path "$daily_volume_zero_timer_unit_path")"
+  else
+    doctor_warn "Daily volume reset timer unit file missing: $(display_path "$daily_volume_zero_timer_unit_path")"
+    doctor_warn 'Run dot stow (or dot install) to link systemd user units'
+  fi
+
+  if has_cmd systemctl; then
+    if systemctl --user is-enabled "$DOT_DAILY_VOLUME_ZERO_TIMER_UNIT" >/dev/null 2>&1; then
+      log_info "Daily volume reset timer enabled: $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+    else
+      doctor_warn "Daily volume reset timer is disabled: $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+      doctor_warn "Enable with: systemctl --user enable --now $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+    fi
+
+    if systemctl --user is-active "$DOT_DAILY_VOLUME_ZERO_TIMER_UNIT" >/dev/null 2>&1; then
+      log_info "Daily volume reset timer active: $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+    else
+      doctor_warn "Daily volume reset timer is not active: $DOT_DAILY_VOLUME_ZERO_TIMER_UNIT"
+    fi
+  else
+    doctor_warn 'Skipping daily volume reset timer checks (systemctl not found)'
   fi
 
   if is_truthy "$INCLUDE_OMARCHY_DIFF_REPOS" || is_truthy "$INCLUDE_OMARCHY_UPDATE_REPOS"; then
@@ -3640,6 +3705,7 @@ cmd_help() {
   printf "$fmt_env" 'DOT_WORKFLOW_WATCH_TIMER_UNIT' 'User systemd timer for workflow polling (default git-workflow-watch.timer)'
   printf "$fmt_env" 'DOT_BROWSER_FREEZE_TIMER_UNIT' 'User systemd timer for browser freeze snapshots (default browser-freeze-snapshot.timer)'
   printf "$fmt_env" 'DOT_DOCTOR_STARTUP_TIMER_UNIT' 'User systemd timer for dot doctor startup notifications (default dot-doctor-startup.timer)'
+  printf "$fmt_env" 'DOT_DAILY_VOLUME_ZERO_TIMER_UNIT' 'User systemd timer for 5am volume reset (default daily-volume-zero.timer)'
   printf "$fmt_env" 'DOT_AGENTS_SYNC_SOURCE' 'Path to AGENTS.md to mirror (default ~/.opencode/AGENTS.md)'
   printf "$fmt_env" 'DOT_AGENTS_SYNC_RULE_FILE' 'Cursor rule file path (default: $DOTFILES_PRIVATE_DIR/agents/.cursor/rules/global-agents.mdc)'
   printf "$fmt_env" 'DOT_AGENTS_SYNC_ON_UPDATE' '1|0 run agents-sync after dot update (default 1)'

--- a/systemd/.config/systemd/user/daily-volume-zero.service
+++ b/systemd/.config/systemd/user/daily-volume-zero.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Notify then set system volume to 0%%
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/bin/daily-volume-zero

--- a/systemd/.config/systemd/user/daily-volume-zero.timer
+++ b/systemd/.config/systemd/user/daily-volume-zero.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run daily volume reset at 5am
+
+[Timer]
+OnCalendar=*-*-* 05:00:00
+Persistent=true
+Unit=daily-volume-zero.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a user systemd timer/service that runs at 5am local time to notify, wait 10 seconds, clear mute, and set the default PipeWire sink volume to 0%.
- Add `dot` install/stow enablement plus `dot doctor` warnings for the script, service unit, timer unit, and timer state.
- Document the daily volume reset and timer override.

## Testing
- `bash -n scripts/.local/bin/daily-volume-zero`
- `bash -n scripts/.local/bin/dot`
- `systemd-analyze verify systemd/.config/systemd/user/daily-volume-zero.service`
- `systemd-analyze verify systemd/.config/systemd/user/daily-volume-zero.timer`
- `systemd-analyze calendar '*-*-* 05:00:00'`
- Stubbed `notify-send`/`wpctl` execution verified notification happens before unmute and volume-zero commands.
- Isolated `dot doctor` probe verified the missing timer warning without relying on the Cloud host as a real Omarchy environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de2a8d5-359b-4f78-ae37-febea59eed65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de2a8d5-359b-4f78-ae37-febea59eed65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

