### PR TITLE
OpenCode: enforce read-only delegations for task subagents

### DIFF
--- a/agents/.config/opencode/agents/general-readonly.md
+++ b/agents/.config/opencode/agents/general-readonly.md
@@ -21,7 +21,5 @@ permission:
     "*": allow
   external_directory:
     "*": ask
-options:
-  enforce_readonly_subagents: true
 ---
 You are a read-only general subagent: investigate, search, read files, and run shell commands when permitted, but do not create, edit, or patch project files. Return findings to the parent agent.

--- a/agents/.config/opencode/agents/general-readonly.md
+++ b/agents/.config/opencode/agents/general-readonly.md
@@ -1,5 +1,5 @@
 ---
-description: General-style parallel subagent that researches and runs commands but cannot modify workspace files (for delegation from read-only primaries).
+description: General-style parallel subagent that researches and runs commands but cannot modify workspace files via file tools (for delegation from read-only primaries).
 mode: subagent
 color: "#64748b"
 permission:
@@ -22,4 +22,4 @@ permission:
   external_directory:
     "*": ask
 ---
-You are a read-only general subagent: investigate, search, read files, and run shell commands when permitted, but do not create, edit, or patch project files. Return findings to the parent agent.
+You are a read-only general subagent: investigate, search, read files, and run shell commands when permitted, but do not create, edit, or patch project files via file tools. Return findings to the parent agent.

--- a/agents/.config/opencode/agents/general-readonly.md
+++ b/agents/.config/opencode/agents/general-readonly.md
@@ -1,0 +1,27 @@
+---
+description: General-style parallel subagent that researches and runs commands but cannot modify workspace files (for delegation from read-only primaries).
+mode: subagent
+color: "#64748b"
+permission:
+  read: allow
+  glob: allow
+  grep: allow
+  list: allow
+  skill: allow
+  webfetch: allow
+  websearch: allow
+  question: deny
+  plan_enter: deny
+  plan_exit: deny
+  edit: deny
+  write: deny
+  apply_patch: deny
+  todowrite: deny
+  bash:
+    "*": allow
+  external_directory:
+    "*": ask
+options:
+  enforce_readonly_subagents: true
+---
+You are a read-only general subagent: investigate, search, read files, and run shell commands when permitted, but do not create, edit, or patch project files. Return findings to the parent agent.

--- a/agents/.config/opencode/plugins/readonly-subagent-task-guard.js
+++ b/agents/.config/opencode/plugins/readonly-subagent-task-guard.js
@@ -52,8 +52,14 @@ function readOnlyByWorkspaceProbes(ruleset) {
 }
 
 function allowsOrAsksTypicalWorkspaceEdits(ruleset) {
-  const action = evaluateAction(ruleset, "edit", EDIT_PROBE_PATH)
-  return action === "allow" || action === "ask"
+  const editAction = evaluateAction(ruleset, "edit", EDIT_PROBE_PATH)
+  const writeAction = evaluateAction(ruleset, "write", WRITE_PROBE_PATH)
+  return (
+    editAction === "allow" ||
+    editAction === "ask" ||
+    writeAction === "allow" ||
+    writeAction === "ask"
+  )
 }
 
 function shouldEnforceReadonlyDelegation(parent) {

--- a/agents/.config/opencode/plugins/readonly-subagent-task-guard.js
+++ b/agents/.config/opencode/plugins/readonly-subagent-task-guard.js
@@ -1,15 +1,25 @@
 /**
  * Forces read-only primary agents to delegate only to subagents that cannot
  * modify workspace files. Built-in `general` / Cursor-style `generalPurpose`
- * are rewritten to `general-readonly` when the invoking session agent is
- * read-only.
+ * are rewritten to `general-readonly` when the delegating agent is read-only.
+ *
+ * Dotfiles agents under agents/.config/opencode/agents (audit):
+ * - reviewer, ask, general-readonly — deny edit and write on normal paths → guarded
+ * - build-locked — edit allow, write deny (can change existing files) → not read-only
+ * - build-ask — edit/write ask → not read-only
+ * - refactorer — sparse permission front matter (inherits writable defaults) → not read-only
+ *
+ * OpenCode native `plan` denies typical source probes but is allowed to delegate
+ * implementation work, so it is excluded here.
  */
 
-const READONLY_PRIMARY_AGENTS = new Set(["reviewer", "ask"])
+/** Agents that match read-only probes but must still be allowed writable subagents */
+const DELEGATION_READONLY_EXCEPTIONS = new Set(["plan"])
 
 const WRITABLE_GENERAL_ALIASES = new Set(["general", "generalPurpose"])
 
 const EDIT_PROBE_PATH = "src/__readonly_subagent_probe__.ts"
+const WRITE_PROBE_PATH = "src/__readonly_subagent_new__.ts"
 
 function wildcardMatch(str, pattern) {
   if (str) str = str.replaceAll("\\", "/")
@@ -33,8 +43,12 @@ function evaluateAction(ruleset, permission, pattern) {
   return rule?.action ?? "ask"
 }
 
-function deniesTypicalWorkspaceEdits(ruleset) {
-  return evaluateAction(ruleset, "edit", EDIT_PROBE_PATH) === "deny"
+/** True when the agent cannot edit or create typical workspace files (last matching rule is deny). */
+function readOnlyByWorkspaceProbes(ruleset) {
+  return (
+    evaluateAction(ruleset, "edit", EDIT_PROBE_PATH) === "deny" &&
+    evaluateAction(ruleset, "write", WRITE_PROBE_PATH) === "deny"
+  )
 }
 
 function allowsOrAsksTypicalWorkspaceEdits(ruleset) {
@@ -44,9 +58,9 @@ function allowsOrAsksTypicalWorkspaceEdits(ruleset) {
 
 function shouldEnforceReadonlyDelegation(parent) {
   if (!parent?.name) return false
-  if (READONLY_PRIMARY_AGENTS.has(parent.name)) return true
+  if (DELEGATION_READONLY_EXCEPTIONS.has(parent.name)) return false
   if (parent.options && parent.options.enforce_readonly_subagents === true) return true
-  return false
+  return readOnlyByWorkspaceProbes(parent.permission)
 }
 
 async function resolveDelegatingAgentName(client, sessionID, query) {
@@ -98,7 +112,6 @@ export const ReadonlySubagentTaskGuard = async ({ client, directory }) => {
       if (!parent || !target) return
 
       if (!shouldEnforceReadonlyDelegation(parent)) return
-      if (!deniesTypicalWorkspaceEdits(parent.permission)) return
       if (!allowsOrAsksTypicalWorkspaceEdits(target.permission)) return
 
       const readonlyGeneral = agents.find((a) => a.name === "general-readonly")

--- a/agents/.config/opencode/plugins/readonly-subagent-task-guard.js
+++ b/agents/.config/opencode/plugins/readonly-subagent-task-guard.js
@@ -1,0 +1,115 @@
+/**
+ * Forces read-only primary agents to delegate only to subagents that cannot
+ * modify workspace files. Built-in `general` / Cursor-style `generalPurpose`
+ * are rewritten to `general-readonly` when the invoking session agent is
+ * read-only.
+ */
+
+const READONLY_PRIMARY_AGENTS = new Set(["reviewer", "ask"])
+
+const WRITABLE_GENERAL_ALIASES = new Set(["general", "generalPurpose"])
+
+const EDIT_PROBE_PATH = "src/__readonly_subagent_probe__.ts"
+
+function wildcardMatch(str, pattern) {
+  if (str) str = str.replaceAll("\\", "/")
+  if (pattern) pattern = pattern.replaceAll("\\", "/")
+  let escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".")
+  if (escaped.endsWith(" .*")) {
+    escaped = escaped.slice(0, -3) + "( .*)?"
+  }
+  const flags = process.platform === "win32" ? "si" : "s"
+  return new RegExp("^" + escaped + "$", flags).test(str)
+}
+
+function evaluateAction(ruleset, permission, pattern) {
+  const matches = ruleset.filter(
+    (r) => wildcardMatch(permission, r.permission) && wildcardMatch(pattern, r.pattern),
+  )
+  const rule = matches[matches.length - 1]
+  return rule?.action ?? "ask"
+}
+
+function deniesTypicalWorkspaceEdits(ruleset) {
+  return evaluateAction(ruleset, "edit", EDIT_PROBE_PATH) === "deny"
+}
+
+function allowsOrAsksTypicalWorkspaceEdits(ruleset) {
+  const action = evaluateAction(ruleset, "edit", EDIT_PROBE_PATH)
+  return action === "allow" || action === "ask"
+}
+
+function shouldEnforceReadonlyDelegation(parent) {
+  if (!parent?.name) return false
+  if (READONLY_PRIMARY_AGENTS.has(parent.name)) return true
+  if (parent.options && parent.options.enforce_readonly_subagents === true) return true
+  return false
+}
+
+async function resolveDelegatingAgentName(client, sessionID, query) {
+  const seen = new Set()
+  let sid = sessionID
+  while (sid && !seen.has(sid)) {
+    seen.add(sid)
+    try {
+      const sessionRes = await client.session.get({
+        path: { id: sid },
+        ...(query ? { query } : {}),
+      })
+      const session = sessionRes.data ?? sessionRes
+      if (session?.agent) return session.agent
+      sid = session.parentID
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+export const ReadonlySubagentTaskGuard = async ({ client, directory }) => {
+  const query = directory ? { directory } : undefined
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "task") return
+
+      const args = output.args
+      const subagentType = args?.subagent_type
+      if (!subagentType || typeof subagentType !== "string") return
+
+      const parentAgentName = await resolveDelegatingAgentName(client, input.sessionID, query)
+      if (!parentAgentName) return
+
+      let agents
+      try {
+        const agentsRes = await client.app.agents(query ? { query } : undefined)
+        agents = agentsRes.data ?? agentsRes
+      } catch {
+        return
+      }
+
+      if (!Array.isArray(agents)) return
+
+      const parent = agents.find((a) => a.name === parentAgentName)
+      const target = agents.find((a) => a.name === subagentType)
+      if (!parent || !target) return
+
+      if (!shouldEnforceReadonlyDelegation(parent)) return
+      if (!deniesTypicalWorkspaceEdits(parent.permission)) return
+      if (!allowsOrAsksTypicalWorkspaceEdits(target.permission)) return
+
+      const readonlyGeneral = agents.find((a) => a.name === "general-readonly")
+      if (WRITABLE_GENERAL_ALIASES.has(subagentType) && readonlyGeneral) {
+        args.subagent_type = "general-readonly"
+        return
+      }
+
+      throw new Error(
+        "Read-only agents cannot delegate to subagents that may modify files. Use subagent_type \"general\" (routed to read-only general), \"explore\", or switch to an agent that can edit.",
+      )
+    },
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Read-only primary agents could still cause workspace writes by delegating through the `task` tool to a writable subagent such as built-in `general`. This adds a global OpenCode plugin that enforces read-only delegation and introduces a `general-readonly` subagent for parallel work without file edits.

## Agent audit (dotfiles)

| Agent | Read-only for this guard? | Reason |
|--------|---------------------------|--------|
| `reviewer` | Yes | `edit` / `write` deny |
| `ask` | Yes | `edit` / `write` deny |
| `general-readonly` | Yes | `edit` / `write` / `apply_patch` deny |
| `build-locked` | No | `edit` allow (mutates existing files) |
| `build-ask` | No | `edit` / `write` ask |
| `refactorer` | No | Sparse permission YAML; inherits writable defaults |

No further dotfiles primaries qualify as fully read-only. The plugin now treats **read-only** as denied **`edit` and `write`** on typical `src/` probe paths (same last-rule semantics as OpenCode), so any future agent with that policy is covered without maintaining a name list. Native OpenCode **`plan`** is excluded because it denies those probes but is expected to delegate implementation work.

`options.enforce_readonly_subagents: true` still forces the guard when organisational policy requires it even if probes do not match.

## Files

- `agents/.config/opencode/plugins/readonly-subagent-task-guard.js`
- `agents/.config/opencode/agents/general-readonly.md`

## Verification

Not run: OpenCode CLI is not available in this environment. After stowing, use `dot opencode-debug` and manual `task` from `reviewer` to `general`.

## Notes

- Bash remains allowed on `general-readonly`; shell-based writes sit outside file-tool permissions (same class of limitation as `explore`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d0993b6-67e8-41f2-9f2b-0debe12d2621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d0993b6-67e8-41f2-9f2b-0debe12d2621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

