### PR TITLE
Fix workflow yamllint and markdownlint errors

### DIFF
--- a/.github/workflows/quickshell-lint.yml
+++ b/.github/workflows/quickshell-lint.yml
@@ -1,3 +1,4 @@
+---
 name: Lint Quickshell
 
 on:

--- a/docs/src/content/docs/omarchy/shell.md
+++ b/docs/src/content/docs/omarchy/shell.md
@@ -70,4 +70,5 @@ A plugin is a folder with `manifest.json` (schema version 1, an `id` like `timmo
 ```bash
 QT_QPA_PLATFORM=wayland omarchy restart shell
 ```
+
 :::


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Lint workflow failures on `omarchy-4-prep`.

## Changes

- Add the required YAML document start (`---`) to `.github/workflows/quickshell-lint.yml` so yamllint passes.
- Add a blank line after the fenced code block in `docs/src/content/docs/omarchy/shell.md` to satisfy markdownlint MD031.

## Verification

- `yamllint -c .yamllint.yml .github/workflows/quickshell-lint.yml`
- `markdownlint-cli2 docs/src/content/docs/omarchy/shell.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589cde1c-bb20-472e-92a5-71ee2e952f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589cde1c-bb20-472e-92a5-71ee2e952f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

