### PR TITLE
Fix Effect usage gaps

### DIFF
--- a/dot/src/commands/Clean.ts
+++ b/dot/src/commands/Clean.ts
@@ -55,9 +55,10 @@ const unstowRepo = (
 
       if (exit !== 0) {
         yield* log.error(`[${scope}] unstow ${folder} failed (exit ${exit})`);
-        return yield* Effect.fail(
-          new LauncherError(`${scope} unstow failed on ${folder}`, exit),
-        );
+        return yield* new LauncherError({
+          message: `${scope} unstow failed on ${folder}`,
+          exitCode: exit,
+        });
       }
     }
   });

--- a/dot/src/commands/Install.ts
+++ b/dot/src/commands/Install.ts
@@ -203,12 +203,10 @@ const stowRepo = (
         yield* log.error(
           `[${scope}] unstow ${folder} failed (exit ${unstowExit})`,
         );
-        return yield* Effect.fail(
-          new LauncherError(
-            `${scope} install unstow failed on ${folder}`,
-            unstowExit,
-          ),
-        );
+        return yield* new LauncherError({
+          message: `${scope} install unstow failed on ${folder}`,
+          exitCode: unstowExit,
+        });
       }
 
       // Build stow command with folder-specific flags
@@ -241,9 +239,10 @@ const stowRepo = (
 
       if (exit !== 0) {
         yield* log.error(`[${scope}] stow ${folder} failed (exit ${exit})`);
-        return yield* Effect.fail(
-          new LauncherError(`${scope} install stow failed on ${folder}`, exit),
-        );
+        return yield* new LauncherError({
+          message: `${scope} install stow failed on ${folder}`,
+          exitCode: exit,
+        });
       }
     }
   });

--- a/dot/src/commands/IsAgent.ts
+++ b/dot/src/commands/IsAgent.ts
@@ -7,7 +7,7 @@ import { detectAgent } from "../lib/agent.js";
  * so shell callers can branch with `if dot is-agent; then ...`.
  */
 export function isAgentCommand(args: readonly string[] = []) {
-  return Effect.sync(() => {
+  return Effect.promise(async () => {
     const detection = detectAgent();
     if (hasOption(args, "--json")) {
       process.stdout.write(`${JSON.stringify(detection)}\n`);

--- a/dot/src/commands/SkillCheck.ts
+++ b/dot/src/commands/SkillCheck.ts
@@ -137,9 +137,7 @@ const collectSkillOriginDiff = (publicDotfiles: string) =>
 
     const parts: string[] = [];
     for (const skill of skills) {
-      const diff = yield* buildSingleDiff(skill).pipe(
-        Effect.catch(() => Effect.succeed("")),
-      );
+      const diff = yield* buildSingleDiff(skill);
       if (!diff) continue;
 
       parts.push(diff);

--- a/dot/src/commands/SkillUpdates.ts
+++ b/dot/src/commands/SkillUpdates.ts
@@ -105,17 +105,7 @@ export const skillUpdates = (opts?: {
     for (const meta of skills) {
       const checked = yield* log.withSpinner(
         `Checking ${meta.name}`,
-        timeoutResult(
-          checkSkill(meta).pipe(
-            Effect.catch((err) =>
-              Effect.succeed({
-                type: "error" as const,
-                reason: String(err),
-              }),
-            ),
-          ),
-          skillCheckTimeout,
-        ),
+        timeoutResult(checkSkill(meta), skillCheckTimeout),
       );
       const result: CheckResult = yield* Option.match(checked, {
         onNone: () =>
@@ -177,9 +167,7 @@ export const skillUpdates = (opts?: {
           const appliedResult = yield* log.withSpinner(
             `Applying ${meta.name}`,
             timeoutResult(
-              applySkillUpdate(meta, result.writeSha).pipe(
-                Effect.catch(() => Effect.succeed(false)),
-              ),
+              applySkillUpdate(meta, result.writeSha),
               skillApplyTimeout,
             ),
           );
@@ -351,10 +339,7 @@ const opencodeReview = (
       // Build the diff report
       const diffResult = yield* log.withSpinner(
         `Building diff for ${meta.name}`,
-        timeoutResult(
-          buildSingleDiff(meta).pipe(Effect.catch(() => Effect.succeed(""))),
-          skillDiffTimeout,
-        ),
+        timeoutResult(buildSingleDiff(meta), skillDiffTimeout),
       );
       const diffContent = Option.getOrElse(diffResult, () => "");
 

--- a/dot/src/commands/SkillUpdates.ts
+++ b/dot/src/commands/SkillUpdates.ts
@@ -238,7 +238,10 @@ export const skillUpdates = (opts?: {
         { cwd: config.publicDotfiles },
       );
       if (!staged.ok) {
-        return yield* Effect.fail(new Error(staged.error ?? "git add failed"));
+        return yield* new LauncherError({
+          message: staged.error ?? "git add failed",
+          exitCode: 1,
+        });
       }
 
       const commitMsg = `Update skills: ${updatedNames.join(", ")}`;
@@ -249,9 +252,10 @@ export const skillUpdates = (opts?: {
         tolerateEmpty: true,
       });
       if (!outcome.ok) {
-        return yield* Effect.fail(
-          new Error(outcome.error ?? "git commit failed"),
-        );
+        return yield* new LauncherError({
+          message: outcome.error ?? "git commit failed",
+          exitCode: 1,
+        });
       }
       if (outcome.committed) {
         yield* log.info(`Committed: ${commitMsg}`);
@@ -278,9 +282,10 @@ export const skillUpdates = (opts?: {
       const total = available + reviewItems.length;
       if (total > 0) {
         yield* log.info(`${total} skill(s) have upstream updates available`);
-        return yield* Effect.fail(
-          new LauncherError("Skill updates available", 1),
-        );
+        return yield* new LauncherError({
+          message: "Skill updates available",
+          exitCode: 1,
+        });
       }
       return false;
     }

--- a/dot/src/commands/Stow.ts
+++ b/dot/src/commands/Stow.ts
@@ -121,12 +121,10 @@ const stowRepo = (
           yield* log.error(
             `[${scope}] unstow ${folder} failed (exit ${unstowExit})`,
           );
-          return yield* Effect.fail(
-            new LauncherError(
-              `${scope} unstow failed on ${folder}`,
-              unstowExit,
-            ),
-          );
+          return yield* new LauncherError({
+            message: `${scope} unstow failed on ${folder}`,
+            exitCode: unstowExit,
+          });
         }
       }
 
@@ -160,9 +158,10 @@ const stowRepo = (
 
       if (exit !== 0) {
         yield* log.error(`[${scope}] stow ${folder} failed (exit ${exit})`);
-        return yield* Effect.fail(
-          new LauncherError(`${scope} stow failed on ${folder}`, exit),
-        );
+        return yield* new LauncherError({
+          message: `${scope} stow failed on ${folder}`,
+          exitCode: exit,
+        });
       }
 
       // Apply any added or changed config and clear any prior emergency state.
@@ -205,9 +204,10 @@ const unstowLegacyInternalFolders = (
         yield* log.error(
           `[public] unstow legacy ${folder} failed (exit ${exit})`,
         );
-        return yield* Effect.fail(
-          new LauncherError(`public legacy unstow failed on ${folder}`, exit),
-        );
+        return yield* new LauncherError({
+          message: `public legacy unstow failed on ${folder}`,
+          exitCode: exit,
+        });
       }
     }
   });

--- a/dot/src/commands/Update.ts
+++ b/dot/src/commands/Update.ts
@@ -204,9 +204,7 @@ const safePull = (name: string, path: string) =>
 
       // Clean up any half-applied rebase left by a failed or interrupted pull
       // before retrying or moving on.
-      yield* gitExitCode(["rebase", "--abort"], { cwd: path }).pipe(
-        Effect.catch(() => Effect.succeed(1)),
-      );
+      yield* gitExitCode(["rebase", "--abort"], { cwd: path });
 
       const reason = Option.isNone(outcome)
         ? `timed out after ${PULL_ATTEMPT_TIMEOUT_SECONDS}s`
@@ -245,9 +243,7 @@ const notifyUpdated = (names: readonly string[]) =>
             .map((n) => `- ${n}`)
             .join("\n")}`;
 
-    yield* executor
-      .exitCode("notify-send", [title, message])
-      .pipe(Effect.catch(() => Effect.succeed(0)));
+    yield* executor.exitCode("notify-send", [title, message]);
   });
 
 function selectedUpdateFlags(opts?: UpdateOptions): readonly string[] {
@@ -300,13 +296,7 @@ const postHooks = Effect.gen(function* () {
 
   yield* log.section("Post-Hooks");
 
-  yield* agentsSync.pipe(
-    Effect.catch(() =>
-      Effect.gen(function* () {
-        yield* log.warn("Agents sync failed (non-fatal)");
-      }),
-    ),
-  );
+  yield* agentsSync;
 });
 
 /**
@@ -329,9 +319,9 @@ const runResumeRefresh = Effect.gen(function* () {
     return;
   }
 
-  const exitCode = yield* executor
-    .exitCode(helper, [ON_RESUME_POST_UPDATE_ARG])
-    .pipe(Effect.catch(() => Effect.succeed(1)));
+  const exitCode = yield* executor.exitCode(helper, [
+    ON_RESUME_POST_UPDATE_ARG,
+  ]);
 
   if (exitCode !== 0) {
     yield* log.warn(`On-resume helper failed (exit ${exitCode})`);

--- a/dot/src/dashboard/services/Dashboard.ts
+++ b/dot/src/dashboard/services/Dashboard.ts
@@ -114,22 +114,7 @@ export class Dashboard extends Context.Service<Dashboard, DashboardService>()(
         );
         yield* PubSub.publish(pubsub, currentState);
         log("Dashboard refresh complete");
-      }).pipe(
-        Effect.withSpan("Dashboard.refresh"),
-        Effect.catch((error) =>
-          Effect.gen(function* () {
-            currentState = buildState(
-              currentState.diffRepos,
-              currentState.bar,
-              new Date(yield* Clock.currentTimeMillis),
-              false,
-              currentState.loaded,
-              String(error),
-            );
-            yield* PubSub.publish(pubsub, currentState);
-          }),
-        ),
-      );
+      }).pipe(Effect.withSpan("Dashboard.refresh"));
 
       yield* refresh;
       yield* refresh.pipe(

--- a/dot/src/dashboard/services/Dashboard.ts
+++ b/dot/src/dashboard/services/Dashboard.ts
@@ -5,6 +5,7 @@ import {
   Layer,
   PubSub,
   Schedule,
+  Schema,
   Stream,
 } from "effect";
 import { existsSync, readFileSync } from "node:fs";
@@ -36,6 +37,14 @@ const BAR_MODULES: readonly DashboardBarModuleId[] = [
   "todo_my_tasks",
   "todo_work",
 ];
+
+/** Domain error for dashboard source command failures. */
+class DashboardError extends Schema.TaggedErrorClass<DashboardError>()(
+  "DashboardError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 /** Service interface for dashboard live source snapshots. */
 interface DashboardService {
@@ -200,7 +209,9 @@ function loadBarValue(
   });
 }
 
-function runDashboardCommand(command: string): Effect.Effect<string, Error> {
+function runDashboardCommand(
+  command: string,
+): Effect.Effect<string, DashboardError> {
   return Effect.tryPromise({
     try: async () => {
       const proc = Bun.spawn(["bash", "-lc", command], {
@@ -217,12 +228,16 @@ function runDashboardCommand(command: string): Effect.Effect<string, Error> {
       const output = await stdout;
       const errorOutput = await stderr;
       if (!output.trim() && exitCode !== 0) {
-        throw new Error(errorOutput.trim() || `exit ${exitCode}`);
+        throw new DashboardError({
+          message: errorOutput.trim() || `exit ${exitCode}`,
+        });
       }
       return output;
     },
     catch: (error) =>
-      error instanceof Error ? error : new Error(String(error)),
+      error instanceof DashboardError
+        ? error
+        : new DashboardError({ message: String(error) }),
   });
 }
 

--- a/dot/src/doctor/checks/browserExtensions.ts
+++ b/dot/src/doctor/checks/browserExtensions.ts
@@ -38,10 +38,8 @@ export const checkBrowserExtensions = Effect.gen(function* () {
     return results;
   }
 
-  let content: string;
-  try {
-    content = readFileSync(configFile, "utf-8");
-  } catch {
+  const content = readTextFile(configFile);
+  if (content === null) {
     results.push({
       severity: "warn",
       message: `Could not read browser checks file: ${displayPath(configFile)}`,
@@ -77,10 +75,8 @@ export const checkBrowserExtensions = Effect.gen(function* () {
       continue;
     }
 
-    let prefs: string;
-    try {
-      prefs = readFileSync(prefsFile, "utf-8");
-    } catch {
+    const prefs = readTextFile(prefsFile);
+    if (prefs === null) {
       results.push({
         severity: "warn",
         message: `Could not read Preferences for ${label}`,
@@ -100,30 +96,7 @@ export const checkBrowserExtensions = Effect.gen(function* () {
       // Fallback: read actual manifest.json files from extension paths on disk
       // (the name may not be cached in Preferences for unpacked extensions)
       if (!found) {
-        try {
-          const parsed = JSON.parse(prefs);
-          const settings = parsed?.extensions?.settings;
-          if (settings && typeof settings === "object") {
-            for (const ext of Object.values(settings) as Array<{
-              path?: string;
-            }>) {
-              if (!ext?.path) continue;
-              const manifestPath = join(ext.path, "manifest.json");
-              if (!existsSync(manifestPath)) continue;
-              try {
-                const manifest = readFileSync(manifestPath, "utf-8");
-                if (manifest.includes(`"name": "${target}"`)) {
-                  found = true;
-                  break;
-                }
-              } catch {
-                /* skip unreadable manifests */
-              }
-            }
-          }
-        } catch {
-          /* ignore JSON parse errors */
-        }
+        found = extensionManifestIncludesName(prefs, target);
       }
     }
 
@@ -143,3 +116,33 @@ export const checkBrowserExtensions = Effect.gen(function* () {
 
   return results;
 });
+
+function readTextFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function extensionManifestIncludesName(prefs: string, target: string): boolean {
+  try {
+    const parsed = JSON.parse(prefs) as {
+      readonly extensions?: {
+        readonly settings?: Record<string, { readonly path?: string }>;
+      };
+    };
+    const settings = parsed.extensions?.settings;
+    if (!settings) return false;
+    for (const ext of Object.values(settings)) {
+      if (!ext.path) continue;
+      const manifestPath = join(ext.path, "manifest.json");
+      if (!existsSync(manifestPath)) continue;
+      const manifest = readTextFile(manifestPath);
+      if (manifest?.includes(`"name": "${target}"`)) return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}

--- a/dot/src/doctor/checks/browserFlags.ts
+++ b/dot/src/doctor/checks/browserFlags.ts
@@ -42,17 +42,15 @@ export const checkBrowserFlags = Effect.gen(function* () {
         });
         flagsOk = false;
       } else {
-        try {
-          const stat = lstatSync(flagFile);
-          if (!stat.isSymbolicLink()) {
-            results.push({
-              severity: "error",
-              message: `${displayPath(flagFile)} is not a symlink`,
-              detail: "Run: dot stow",
-            });
-            flagsOk = false;
-          }
-        } catch {
+        const isSymlink = isSymbolicLink(flagFile);
+        if (isSymlink === null) {
+          flagsOk = false;
+        } else if (!isSymlink) {
+          results.push({
+            severity: "error",
+            message: `${displayPath(flagFile)} is not a symlink`,
+            detail: "Run: dot stow",
+          });
           flagsOk = false;
         }
       }
@@ -115,3 +113,11 @@ export const checkBrowserFlags = Effect.gen(function* () {
 
   return results;
 });
+
+function isSymbolicLink(path: string): boolean | null {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return null;
+  }
+}

--- a/dot/src/doctor/checks/hardwareVideo.ts
+++ b/dot/src/doctor/checks/hardwareVideo.ts
@@ -154,8 +154,8 @@ export const checkHardwareVideo = Effect.gen(function* () {
 
   for (const { name, wrapper } of browsers) {
     if (existsSync(wrapper)) {
-      try {
-        const content = readFileSync(wrapper, "utf-8");
+      const content = readTextFile(wrapper);
+      if (content !== null) {
         const driverMatch = content.match(
           /^\s*export\s+LIBVA_DRIVER_NAME=(\S+)/m,
         );
@@ -171,8 +171,6 @@ export const checkHardwareVideo = Effect.gen(function* () {
             message: `${name} wrapper forces Mesa EGL (hybrid GPU fix)`,
           });
         }
-      } catch {
-        /* ignore */
       }
     }
   }
@@ -185,8 +183,8 @@ export const checkHardwareVideo = Effect.gen(function* () {
 
   for (const { name, path } of flagsFiles) {
     if (existsSync(path)) {
-      try {
-        const content = readFileSync(path, "utf-8");
+      const content = readTextFile(path);
+      if (content !== null) {
         if (
           /AcceleratedVideoDecodeLinuxGL|VaapiVideoDecodeLinuxGL/.test(content)
         ) {
@@ -201,8 +199,6 @@ export const checkHardwareVideo = Effect.gen(function* () {
             detail: "AcceleratedVideoDecodeLinuxGL or VaapiVideoDecodeLinuxGL",
           });
         }
-      } catch {
-        /* ignore */
       }
     }
   }
@@ -250,3 +246,11 @@ export const checkHardwareVideo = Effect.gen(function* () {
 
   return results;
 });
+
+function readTextFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}

--- a/dot/src/doctor/checks/pacmanHooks.ts
+++ b/dot/src/doctor/checks/pacmanHooks.ts
@@ -16,10 +16,8 @@ export const checkPacmanHooks = Effect.gen(function* () {
     return results;
   }
 
-  let hookFiles: string[];
-  try {
-    hookFiles = readdirSync(hooksSource).filter((f) => f.endsWith(".hook"));
-  } catch {
+  const hookFiles = hookFileNames(hooksSource);
+  if (hookFiles === null) {
     return results;
   }
 
@@ -36,30 +34,42 @@ export const checkPacmanHooks = Effect.gen(function* () {
       continue;
     }
 
-    // Compare contents
-    try {
-      const sourceContent = readFileSync(sourceFile, "utf-8");
-      const installedContent = readFileSync(installedFile, "utf-8");
-
-      if (sourceContent !== installedContent) {
-        results.push({
-          severity: "warn",
-          message: `Pacman hook out of date: ${hookName}`,
-          detail: `Run: pkexec install -Dm644 ${sourceFile} ${installedFile}`,
-        });
-      } else {
-        results.push({
-          severity: "ok",
-          message: `Pacman hook installed: ${hookName}`,
-        });
-      }
-    } catch {
+    const sourceContent = readTextFile(sourceFile);
+    const installedContent = readTextFile(installedFile);
+    if (sourceContent === null || installedContent === null) {
       results.push({
         severity: "warn",
         message: `Could not compare pacman hook: ${hookName}`,
+      });
+    } else if (sourceContent !== installedContent) {
+      results.push({
+        severity: "warn",
+        message: `Pacman hook out of date: ${hookName}`,
+        detail: `Run: pkexec install -Dm644 ${sourceFile} ${installedFile}`,
+      });
+    } else {
+      results.push({
+        severity: "ok",
+        message: `Pacman hook installed: ${hookName}`,
       });
     }
   }
 
   return results;
 });
+
+function hookFileNames(path: string): string[] | null {
+  try {
+    return readdirSync(path).filter((fileName) => fileName.endsWith(".hook"));
+  } catch {
+    return null;
+  }
+}
+
+function readTextFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}

--- a/dot/src/git/commands/Commit.ts
+++ b/dot/src/git/commands/Commit.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { gitOutput } from "../../lib/git.js";
 import { CommandExecutor } from "../../services/CommandExecutor.js";
 import { normalizeGitHubSlug } from "../../services/GitConfig.js";
@@ -217,9 +217,16 @@ export interface GitCommitOptions {
 
 const handleCommitError = handleCommandError("dot git-commit");
 
-/** Fail the command with a plain message rendered by {@link handleCommitError}. */
-function failCommit(message: string): Effect.Effect<never, Error> {
-  return Effect.fail(new Error(message));
+class GitCommitError extends Schema.TaggedErrorClass<GitCommitError>()(
+  "GitCommitError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+/** Fail the command with a tagged message rendered by {@link handleCommitError}. */
+function failCommit(message: string): Effect.Effect<never, GitCommitError> {
+  return Effect.fail(new GitCommitError({ message }));
 }
 
 /** Run a read-only git command, resolving to trimmed stdout or "" on failure. */

--- a/dot/src/git/commands/Workflows.ts
+++ b/dot/src/git/commands/Workflows.ts
@@ -197,14 +197,7 @@ function loadWorkflowBarRepo(
         : null,
       runs: filteredRuns,
     } satisfies WorkflowRepoRuns;
-  }).pipe(
-    Effect.catch((error) =>
-      Effect.succeed({
-        ...emptyRepo(repo.github),
-        error: formatError(error),
-      }),
-    ),
-  );
+  });
 }
 
 function workflowRunsForSlug(

--- a/dot/src/git/commands/rows.ts
+++ b/dot/src/git/commands/rows.ts
@@ -37,7 +37,7 @@ export function formatCommandError(error: unknown): string {
 /** Print a labelled command error and exit non-zero. */
 export function handleCommandError(label: string) {
   return Effect.catch((error: unknown) =>
-    Effect.sync(() => {
+    Effect.promise(async () => {
       console.error(`[${label}] ${formatCommandError(error)}`);
       process.exit(1);
     }),

--- a/dot/src/git/context/build.ts
+++ b/dot/src/git/context/build.ts
@@ -7,7 +7,7 @@
  * (the OpenCode branch-context plugin) format that one snapshot, so the two
  * consumers can never drift.
  */
-import { Effect } from "effect";
+import { Clock, Effect } from "effect";
 import { CommandExecutor } from "../../services/CommandExecutor.js";
 import { gitOutput } from "../../lib/git.js";
 import { GitHub } from "../services/GitHub.js";
@@ -332,11 +332,13 @@ function collectCommits(
       `--format=${COMMIT_SEPARATOR}%H`,
       ...range.args,
     ]);
+    const now = yield* Clock.currentTimeMillis;
     const records = parseCommits(
       logOutput,
       aheadHashes,
       baseExists,
       parseNumstatLog(numstatLog),
+      now,
     );
     return { range, records };
   });
@@ -466,6 +468,7 @@ function parseCommits(
   aheadHashes: ReadonlySet<string>,
   baseExists: boolean,
   numstatByCommit: Map<string, Map<string, DiffCounts>>,
+  now: number,
 ): CommitRecord[] {
   const records: {
     shortHash: string;
@@ -485,7 +488,7 @@ function parseCommits(
       records.push({
         isoDate,
         shortHash,
-        relativeTime: formatRelativeTimeAgo(isoDate),
+        relativeTime: formatRelativeTimeAgo(isoDate, now),
         subject,
         pushed: baseExists && !aheadHashes.has(fullHash),
         files: [],

--- a/dot/src/git/context/build.ts
+++ b/dot/src/git/context/build.ts
@@ -7,7 +7,7 @@
  * (the OpenCode branch-context plugin) format that one snapshot, so the two
  * consumers can never drift.
  */
-import { Clock, Effect } from "effect";
+import { Clock, Effect, Schema } from "effect";
 import { CommandExecutor } from "../../services/CommandExecutor.js";
 import { gitOutput } from "../../lib/git.js";
 import { GitHub } from "../services/GitHub.js";
@@ -40,6 +40,13 @@ const MIN_RECENT_COMMIT_LIMIT = 10;
  * byte, so it cleanly delimits commit headers from their file lists.
  */
 const COMMIT_SEPARATOR = "\x1e";
+
+class BranchContextError extends Schema.TaggedErrorClass<BranchContextError>()(
+  "BranchContextError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 /** Attempt to run a git command, returning empty string on failure. */
 function tryGit(
@@ -384,21 +391,17 @@ interface BranchDiffContext {
  */
 function resolveBranchDiff(
   context: BranchDiffContext,
-): Effect.Effect<BranchDiff, Error, CommandExecutor> {
+): Effect.Effect<BranchDiff, BranchContextError, CommandExecutor> {
   return Effect.gen(function* () {
     if (context.onDefaultBranch) {
-      return yield* Effect.fail(
-        new Error(
-          `On the default branch (${context.defaultBranch}); --branch-diff requires a feature branch.`,
-        ),
-      );
+      return yield* new BranchContextError({
+        message: `On the default branch (${context.defaultBranch}); --branch-diff requires a feature branch.`,
+      });
     }
     if (!context.defaultRefExists) {
-      return yield* Effect.fail(
-        new Error(
-          `Cannot resolve default branch ref '${context.defaultBranchRef}' for --branch-diff.`,
-        ),
-      );
+      return yield* new BranchContextError({
+        message: `Cannot resolve default branch ref '${context.defaultBranchRef}' for --branch-diff.`,
+      });
     }
 
     const mergeBase = yield* tryGit([
@@ -407,11 +410,9 @@ function resolveBranchDiff(
       "HEAD",
     ]);
     if (!mergeBase) {
-      return yield* Effect.fail(
-        new Error(
-          `Cannot find a merge base between ${context.defaultBranchRef} and HEAD for --branch-diff.`,
-        ),
-      );
+      return yield* new BranchContextError({
+        message: `Cannot find a merge base between ${context.defaultBranchRef} and HEAD for --branch-diff.`,
+      });
     }
 
     const diff = yield* tryGit(["diff", mergeBase]);

--- a/dot/src/git/doctor/gitConfig.ts
+++ b/dot/src/git/doctor/gitConfig.ts
@@ -14,24 +14,22 @@ export const checkGitConfig = Effect.gen(function* () {
 
   if (existsSync(gitConfigDotfiles)) {
     if (existsSync(gitConfigFile)) {
-      try {
-        const content = readFileSync(gitConfigFile, "utf-8");
-        if (content.includes(`path = ${gitIncludePath}`)) {
-          results.push({
-            severity: "ok",
-            message: "Git config includes managed dotfiles settings",
-          });
-        } else {
-          results.push({
-            severity: "warn",
-            message: "Git config is missing the dotfiles include",
-            detail: `Run: git config --global --add include.path '${gitIncludePath}'`,
-          });
-        }
-      } catch {
+      const content = readTextFile(gitConfigFile);
+      if (content === null) {
         results.push({
           severity: "warn",
           message: "Could not read git config file",
+        });
+      } else if (content.includes(`path = ${gitIncludePath}`)) {
+        results.push({
+          severity: "ok",
+          message: "Git config includes managed dotfiles settings",
+        });
+      } else {
+        results.push({
+          severity: "warn",
+          message: "Git config is missing the dotfiles include",
+          detail: `Run: git config --global --add include.path '${gitIncludePath}'`,
         });
       }
     } else {
@@ -51,3 +49,11 @@ export const checkGitConfig = Effect.gen(function* () {
 
   return results;
 });
+
+function readTextFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}

--- a/dot/src/git/services/CommitSuggest.ts
+++ b/dot/src/git/services/CommitSuggest.ts
@@ -88,11 +88,9 @@ export class CommitSuggest extends Context.Service<
     suggest: (diff, recentCommits) =>
       Effect.gen(function* () {
         if (!diff.trim()) {
-          return yield* Effect.fail(
-            new CommitSuggestError({
-              message: "No staged changes to generate suggestions for",
-            }),
-          );
+          return yield* new CommitSuggestError({
+            message: "No staged changes to generate suggestions for",
+          });
         }
 
         // Discover fast model (cached after first call)

--- a/dot/src/git/services/DotDiff.ts
+++ b/dot/src/git/services/DotDiff.ts
@@ -310,10 +310,7 @@ export class DotDiff extends Context.Service<DotDiff, DotDiffService>()(
                   ],
                   { cwd: repoPath },
                 )
-                .pipe(
-                  Effect.timeoutOption(FETCH_TIMEOUT),
-                  Effect.catch(() => Effect.succeed(Option.some(1))),
-                );
+                .pipe(Effect.timeoutOption(FETCH_TIMEOUT));
 
               if (Option.isNone(fetchExit)) {
                 yield* outputLog.warn(
@@ -335,10 +332,7 @@ export class DotDiff extends Context.Service<DotDiff, DotDiffService>()(
                     ],
                     { cwd: repoPath },
                   )
-                  .pipe(
-                    Effect.timeoutOption(FETCH_TIMEOUT),
-                    Effect.catch(() => Effect.succeed(Option.some(1))),
-                  );
+                  .pipe(Effect.timeoutOption(FETCH_TIMEOUT));
                 if (Option.isNone(fallbackExit)) {
                   yield* outputLog.warn(
                     `Fallback fetch timed out after ${FETCH_TIMEOUT_SECONDS}s for ${name}: ${displayPath(repoPath)}`,

--- a/dot/src/git/services/DotDiff.ts
+++ b/dot/src/git/services/DotDiff.ts
@@ -1,4 +1,12 @@
-import { Context, Duration, Effect, Layer, Option, Schema } from "effect";
+import {
+  Clock,
+  Context,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  Schema,
+} from "effect";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, join } from "path";
 import { createHash } from "crypto";
@@ -26,7 +34,11 @@ const FETCH_TIMEOUT = Duration.seconds(FETCH_TIMEOUT_SECONDS);
 const FETCH_CACHE_DIR = join(CACHE_DIR, "dot", "fetch-upstream");
 
 /** Check if a fetch is needed based on TTL cache */
-function shouldFetch(repoPath: string, upstreamRef: string): boolean {
+function shouldFetch(
+  repoPath: string,
+  upstreamRef: string,
+  nowSeconds: number,
+): boolean {
   if (FETCH_TTL_SECONDS <= 0) return true;
 
   mkdirSync(FETCH_CACHE_DIR, { recursive: true });
@@ -38,10 +50,9 @@ function shouldFetch(repoPath: string, upstreamRef: string): boolean {
   try {
     const lastAttempt = parseInt(readFileSync(cacheFile, "utf-8").trim(), 10);
     if (!isNaN(lastAttempt)) {
-      const now = Math.floor(Date.now() / 1000);
-      if (now - lastAttempt < FETCH_TTL_SECONDS) {
+      if (nowSeconds - lastAttempt < FETCH_TTL_SECONDS) {
         log(
-          `${repoPath}: fetch cache hit (${now - lastAttempt}s < ${FETCH_TTL_SECONDS}s TTL)`,
+          `${repoPath}: fetch cache hit (${nowSeconds - lastAttempt}s < ${FETCH_TTL_SECONDS}s TTL)`,
         );
         return false;
       }
@@ -54,7 +65,11 @@ function shouldFetch(repoPath: string, upstreamRef: string): boolean {
 }
 
 /** Record a fetch attempt timestamp in the TTL cache */
-function recordFetch(repoPath: string, upstreamRef: string): void {
+function recordFetch(
+  repoPath: string,
+  upstreamRef: string,
+  nowSeconds: number,
+): void {
   if (FETCH_TTL_SECONDS <= 0) return;
 
   try {
@@ -63,8 +78,7 @@ function recordFetch(repoPath: string, upstreamRef: string): void {
       .update(`${repoPath}\n${upstreamRef}\n`)
       .digest("hex");
     const cacheFile = join(FETCH_CACHE_DIR, cacheKey);
-    const now = Math.floor(Date.now() / 1000);
-    writeFileSync(cacheFile, `${now}\n`);
+    writeFileSync(cacheFile, `${nowSeconds}\n`);
   } catch {
     // Non-fatal — cache write failure doesn't block diff
   }
@@ -277,7 +291,10 @@ export class DotDiff extends Context.Service<DotDiff, DotDiffService>()(
               .pipe(Effect.catch(() => Effect.succeed("")));
 
             const trimmedRef = upstreamRef.trim();
-            if (trimmedRef && shouldFetch(repoPath, trimmedRef)) {
+            const nowSeconds = Math.floor(
+              (yield* Clock.currentTimeMillis) / 1000,
+            );
+            if (trimmedRef && shouldFetch(repoPath, trimmedRef, nowSeconds)) {
               const [remoteName] = trimmedRef.split("/", 1);
               const remoteBranch = trimmedRef.slice(remoteName.length + 1);
               const fetchExit = yield* executor
@@ -328,7 +345,7 @@ export class DotDiff extends Context.Service<DotDiff, DotDiffService>()(
                   );
                 }
               }
-              recordFetch(repoPath, trimmedRef);
+              recordFetch(repoPath, trimmedRef, nowSeconds);
             }
           }
 

--- a/dot/src/git/services/GitDiffWaybarCache.ts
+++ b/dot/src/git/services/GitDiffWaybarCache.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, Schema } from "effect";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { CACHE_DIR } from "../../lib/paths.js";
@@ -23,6 +23,13 @@ interface GitDiffWaybarCacheService {
   ) => readonly string[];
 }
 
+class GitDiffWaybarCacheError extends Schema.TaggedErrorClass<GitDiffWaybarCacheError>()(
+  "GitDiffWaybarCacheError",
+  {
+    message: Schema.String,
+  },
+) {}
+
 /** Effect service for {@link GitDiffWaybarCacheService} */
 export class GitDiffWaybarCache extends Context.Service<
   GitDiffWaybarCache,
@@ -38,7 +45,7 @@ export class GitDiffWaybarCache extends Context.Service<
           return data;
         },
         catch: (error) =>
-          error instanceof Error ? error : new Error(String(error)),
+          new GitDiffWaybarCacheError({ message: String(error) }),
       }).pipe(Effect.catch(() => Effect.succeed(null))),
 
     parseChangedNames: (data: GitDiffWaybarCacheData): readonly string[] => {

--- a/dot/src/git/services/GitHub.ts
+++ b/dot/src/git/services/GitHub.ts
@@ -149,15 +149,13 @@ export class GitHub extends Context.Service<GitHub, GitHubService>()("GitHub") {
           return;
         }
 
-        return yield* Effect.fail(
-          new GitHubError({
-            command: formatGhCommand(args),
-            exitCode: 1,
-            stderr: `GitHub REST API rate limit exhausted; resets at ${new Date(snapshot.resetEpochSeconds * 1000).toISOString()}`,
-            retryable: false,
-            rateLimited: true,
-          }),
-        );
+        return yield* new GitHubError({
+          command: formatGhCommand(args),
+          exitCode: 1,
+          stderr: `GitHub REST API rate limit exhausted; resets at ${new Date(snapshot.resetEpochSeconds * 1000).toISOString()}`,
+          retryable: false,
+          rateLimited: true,
+        });
       });
 
       const runAttempt = (args: readonly string[]) =>
@@ -187,7 +185,7 @@ export class GitHub extends Context.Service<GitHub, GitHubService>()("GitHub") {
         const { error } = result;
         clearRateLimitCache(error);
         if (!shouldRetry(error, attempt, retries)) {
-          return yield* Effect.fail(error);
+          return yield* error;
         }
 
         const delaySeconds = retryDelaySeconds(attempt);

--- a/dot/src/git/services/GitNotifications.ts
+++ b/dot/src/git/services/GitNotifications.ts
@@ -178,19 +178,21 @@ export class GitNotifications extends Context.Service<
           log(`Refresh complete: ${threads.length} notification threads`);
         }).pipe(
           Effect.withSpan("GitNotifications.refresh"),
-          Effect.catch((error) => {
-            const query = normalizeQuery(opts);
-            currentState = buildState(
-              currentState.threads,
-              new Date(),
-              false,
-              currentState.loaded,
-              query,
-              hiddenThreadIds,
-              formatGhError(error),
-            );
-            return PubSub.publish(pubsub, currentState).pipe(Effect.asVoid);
-          }),
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              const query = normalizeQuery(opts);
+              currentState = buildState(
+                currentState.threads,
+                new Date(yield* Clock.currentTimeMillis),
+                false,
+                currentState.loaded,
+                query,
+                hiddenThreadIds,
+                formatGhError(error),
+              );
+              yield* PubSub.publish(pubsub, currentState);
+            }),
+          ),
         );
 
       const filterBarThreadsIfNeeded = (

--- a/dot/src/git/services/RepoWatcher.ts
+++ b/dot/src/git/services/RepoWatcher.ts
@@ -102,13 +102,7 @@ export class RepoWatcher extends Context.Service<
 
         log("Waybar cache miss — falling back to full poll");
         yield* poll;
-      }).pipe(
-        Effect.withSpan("RepoWatcher.initialLoad"),
-        Effect.catch(() => {
-          log("Initial load error — falling back to full poll");
-          return poll;
-        }),
-      );
+      }).pipe(Effect.withSpan("RepoWatcher.initialLoad"));
 
       // Run initial load
       yield* initialLoad;

--- a/dot/src/git/services/WorkflowRuns.ts
+++ b/dot/src/git/services/WorkflowRuns.ts
@@ -1,4 +1,4 @@
-import { Clock, Context, Effect, Layer, PubSub, Stream } from "effect";
+import { Clock, Context, Effect, Layer, PubSub, Schema, Stream } from "effect";
 import { existsSync } from "node:fs";
 import type {
   WorkflowRepoRuns,
@@ -30,6 +30,13 @@ const DEBUG = !!envString(ENV.DOT_DEBUG);
 const log = (msg: string) => {
   if (DEBUG) console.error(`[dot:WorkflowRuns] ${msg}`);
 };
+
+class WorkflowRunsError extends Schema.TaggedErrorClass<WorkflowRunsError>()(
+  "WorkflowRunsError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 interface WorkflowRunsService {
   /** Subscribe to workflow run state snapshots */
@@ -145,7 +152,9 @@ export class WorkflowRuns extends Context.Service<
         }).pipe(Effect.provideService(CommandExecutor, executor))).trim();
 
         if (!branch) {
-          return yield* Effect.fail(new Error("current branch not found"));
+          return yield* new WorkflowRunsError({
+            message: "current branch not found",
+          });
         }
 
         const sha = (yield* gitOutput(["rev-parse", "HEAD"], {
@@ -304,18 +313,20 @@ export class WorkflowRuns extends Context.Service<
           log(`Refresh complete: ${repos.length} workflow repos`);
         }).pipe(
           Effect.withSpan("WorkflowRuns.refresh"),
-          Effect.catch((error) => {
-            log(`Refresh failed: ${formatGhError(error)}`);
-            currentState = buildState(
-              currentState.repos,
-              new Date(),
-              false,
-              currentState.loaded,
-              formatGhError(error),
-              { since: opts?.since ?? currentState.since ?? undefined },
-            );
-            return PubSub.publish(pubsub, currentState).pipe(Effect.asVoid);
-          }),
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              log(`Refresh failed: ${formatGhError(error)}`);
+              currentState = buildState(
+                currentState.repos,
+                new Date(yield* Clock.currentTimeMillis),
+                false,
+                currentState.loaded,
+                formatGhError(error),
+                { since: opts?.since ?? currentState.since ?? undefined },
+              );
+              yield* PubSub.publish(pubsub, currentState);
+            }),
+          ),
         );
 
       return {

--- a/dot/src/git/services/WorkflowRuns.ts
+++ b/dot/src/git/services/WorkflowRuns.ts
@@ -242,67 +242,25 @@ export class WorkflowRuns extends Context.Service<
         "id,state",
       ];
 
-      const refresh = (opts?: WorkflowRunQueryOptions) =>
-        Effect.gen(function* () {
-          log("Refreshing workflow runs...");
-          const targets = workflowTargets(config);
-          const message = workflowTargetMessage(config, targets.length);
+      const refresh = Effect.fn("WorkflowRuns.refresh")(function* (
+        opts?: WorkflowRunQueryOptions,
+      ) {
+        log("Refreshing workflow runs...");
+        const targets = workflowTargets(config);
+        const message = workflowTargetMessage(config, targets.length);
+        currentState = buildState(
+          targets.map(targetToLoadingRepo),
+          new Date(yield* Clock.currentTimeMillis),
+          true,
+          currentState.loaded,
+          message,
+          opts,
+        );
+        yield* PubSub.publish(pubsub, currentState);
+
+        if (targets.length === 0) {
           currentState = buildState(
-            targets.map(targetToLoadingRepo),
-            new Date(yield* Clock.currentTimeMillis),
-            true,
-            currentState.loaded,
-            message,
-            opts,
-          );
-          yield* PubSub.publish(pubsub, currentState);
-
-          if (targets.length === 0) {
-            currentState = buildState(
-              [],
-              new Date(yield* Clock.currentTimeMillis),
-              false,
-              true,
-              message,
-              opts,
-            );
-            yield* PubSub.publish(pubsub, currentState);
-            return;
-          }
-
-          const hasGh = yield* github.isAvailable();
-          if (!hasGh) {
-            currentState = buildState(
-              targets.map((target) => ({
-                ...emptyRepo(target.slug),
-                error: "gh CLI not found",
-              })),
-              new Date(yield* Clock.currentTimeMillis),
-              false,
-              true,
-              message,
-              opts,
-            );
-            yield* PubSub.publish(pubsub, currentState);
-            return;
-          }
-
-          const repos = yield* Effect.all(
-            targets.map((target) =>
-              fetchRepoRuns(target, opts).pipe(
-                Effect.catch((error) =>
-                  Effect.succeed({
-                    ...emptyRepo(target.slug),
-                    error: formatGhError(error),
-                  }),
-                ),
-              ),
-            ),
-            { concurrency: 4 },
-          );
-
-          currentState = buildState(
-            repos,
+            [],
             new Date(yield* Clock.currentTimeMillis),
             false,
             true,
@@ -310,24 +268,51 @@ export class WorkflowRuns extends Context.Service<
             opts,
           );
           yield* PubSub.publish(pubsub, currentState);
-          log(`Refresh complete: ${repos.length} workflow repos`);
-        }).pipe(
-          Effect.withSpan("WorkflowRuns.refresh"),
-          Effect.catch((error) =>
-            Effect.gen(function* () {
-              log(`Refresh failed: ${formatGhError(error)}`);
-              currentState = buildState(
-                currentState.repos,
-                new Date(yield* Clock.currentTimeMillis),
-                false,
-                currentState.loaded,
-                formatGhError(error),
-                { since: opts?.since ?? currentState.since ?? undefined },
-              );
-              yield* PubSub.publish(pubsub, currentState);
-            }),
+          return;
+        }
+
+        const hasGh = yield* github.isAvailable();
+        if (!hasGh) {
+          currentState = buildState(
+            targets.map((target) => ({
+              ...emptyRepo(target.slug),
+              error: "gh CLI not found",
+            })),
+            new Date(yield* Clock.currentTimeMillis),
+            false,
+            true,
+            message,
+            opts,
+          );
+          yield* PubSub.publish(pubsub, currentState);
+          return;
+        }
+
+        const repos = yield* Effect.all(
+          targets.map((target) =>
+            fetchRepoRuns(target, opts).pipe(
+              Effect.catch((error) =>
+                Effect.succeed({
+                  ...emptyRepo(target.slug),
+                  error: formatGhError(error),
+                }),
+              ),
+            ),
           ),
+          { concurrency: 4 },
         );
+
+        currentState = buildState(
+          repos,
+          new Date(yield* Clock.currentTimeMillis),
+          false,
+          true,
+          message,
+          opts,
+        );
+        yield* PubSub.publish(pubsub, currentState);
+        log(`Refresh complete: ${repos.length} workflow repos`);
+      });
 
       return {
         subscribe: () => Stream.fromPubSub(pubsub),

--- a/dot/src/git/services/relativeTime.ts
+++ b/dot/src/git/services/relativeTime.ts
@@ -10,11 +10,14 @@ const RELATIVE_TIME_UNITS: readonly {
 ];
 
 /** Format an ISO timestamp as a compact relative time. */
-export function formatRelativeTimeAgo(value: string | null): string {
+export function formatRelativeTimeAgo(
+  value: string | null,
+  now: number = Date.now(),
+): string {
   const time = new Date(value ?? "").getTime();
   if (!Number.isFinite(time)) return "unknown";
 
-  const seconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
+  const seconds = Math.max(0, Math.floor((now - time) / 1000));
   const unit = RELATIVE_TIME_UNITS.find(
     (candidate) => seconds < candidate.limit,
   );

--- a/dot/src/git/tui/CommitView.ts
+++ b/dot/src/git/tui/CommitView.ts
@@ -8,7 +8,7 @@ import {
   fg,
   bold,
 } from "@opentui/core";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import type { CommitSuggestion } from "../../types.js";
 import type { Theme } from "../../theme.js";
 import type { GitStagingService } from "../services/GitStaging.js";
@@ -39,6 +39,13 @@ const HELP_SUGGESTIONS: readonly HelpEntry[] = [
 ];
 
 const log = (msg: string) => console.error(`[dot:CommitView] ${msg}`);
+
+class CommitViewError extends Schema.TaggedErrorClass<CommitViewError>()(
+  "CommitViewError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 /** Configuration and callbacks for the commit view */
 export interface CommitViewOptions {
@@ -288,7 +295,8 @@ export class CommitView {
           await proc.exited;
           return stdout;
         },
-        catch: (e) => new Error(`Failed to get diff: ${e}`),
+        catch: (error) =>
+          new CommitViewError({ message: `Failed to get diff: ${error}` }),
       });
 
       // Get recent commits from this repo and others
@@ -321,7 +329,7 @@ export class CommitView {
   /**
    * Gather recent commits from the target repo for style reference.
    */
-  private gatherRecentCommits(): Effect.Effect<readonly string[], Error> {
+  private gatherRecentCommits() {
     return Effect.gen({ self: this }, function* () {
       const targetCommits = yield* this.gitStaging.getRecentCommits(
         this.repoPath,

--- a/dot/src/index.ts
+++ b/dot/src/index.ts
@@ -706,6 +706,9 @@ if (mode.type === "native" && mode.command === "mcp") {
     const commitSuggest = yield* CommitSuggest;
     const renderer = yield* Renderer;
     const toast = yield* Toast;
+    const services = yield* Effect.context<never>();
+    const runFork = Effect.runForkWith(services);
+    const runPromise = Effect.runPromiseWith(services);
     log("Services ready");
 
     const commandRunner = createCommandRunner(renderer, toast);
@@ -719,24 +722,24 @@ if (mode.type === "native" && mode.command === "mcp") {
         gitStaging,
         commitSuggest,
         onRefreshDiff: () => {
-          Effect.runFork(watcher.refresh());
+          runFork(watcher.refresh());
         },
         onRefreshGitLog: () => {
-          Effect.runFork(gitLog.refresh());
+          runFork(gitLog.refresh());
         },
         onRefreshWorkflows: () => {
-          Effect.runFork(workflows.refresh(workflowOpts));
+          runFork(workflows.refresh(workflowOpts));
         },
         onRefreshNotifications: () => {
-          Effect.runFork(notifications.refresh(notificationOpts));
+          runFork(notifications.refresh(notificationOpts));
         },
         onRefreshDashboard: () => {
-          Effect.runFork(dashboard.refresh());
-          Effect.runFork(notifications.refresh(notificationOpts));
-          Effect.runFork(workflows.refresh(workflowOpts));
+          runFork(dashboard.refresh());
+          runFork(notifications.refresh(notificationOpts));
+          runFork(workflows.refresh(workflowOpts));
         },
         onNotificationAction: (action, threadId) => {
-          Effect.runFork(
+          runFork(
             runNotificationAction(
               notifications,
               action,
@@ -745,20 +748,18 @@ if (mode.type === "native" && mode.command === "mcp") {
             ),
           );
         },
-        listNotes: () => Effect.runPromise(notes.list()),
-        listAllNotes: () => Effect.runPromise(notes.listAll()),
-        readNote: (filePath) => Effect.runPromise(notes.read(filePath)),
-        deleteNote: (filePath) => Effect.runPromise(notes.delete(filePath)),
+        listNotes: () => runPromise(notes.list()),
+        listAllNotes: () => runPromise(notes.listAll()),
+        readNote: (filePath) => runPromise(notes.read(filePath)),
+        deleteNote: (filePath) => runPromise(notes.delete(filePath)),
         createNoteDraft: (kind, name, description) =>
-          Effect.runPromise(notes.createDraft(kind, name, description)),
+          runPromise(notes.createDraft(kind, name, description)),
         finaliseNoteDraft: (filePath) =>
-          Effect.runPromise(notes.finaliseDraft(filePath)).then(() => {}),
+          runPromise(notes.finaliseDraft(filePath)).then(() => {}),
         finaliseNoteEdit: (filePath) =>
-          Effect.runPromise(notes.finaliseEdit(filePath)).then(() => {}),
+          runPromise(notes.finaliseEdit(filePath)).then(() => {}),
         updateNotePriority: (filePath, priority) =>
-          Effect.runPromise(notes.setPriority(filePath, priority)).then(
-            () => {},
-          ),
+          runPromise(notes.setPriority(filePath, priority)).then(() => {}),
       },
       {
         initialView,

--- a/dot/src/index.ts
+++ b/dot/src/index.ts
@@ -648,7 +648,7 @@ if (mode.type === "native" && mode.command === "mcp") {
     const canonical = getCliCommand(command)?.name ?? command;
     const handler = nativeCommandHandlers[canonical];
     if (handler) return handler(args);
-    return Effect.sync(() => {
+    return Effect.promise(async () => {
       console.error(`dot: unknown command '${command}'`);
       process.exit(1);
     });
@@ -660,7 +660,7 @@ if (mode.type === "native" && mode.command === "mcp") {
       : resolveNative(mode.command, mode.args).pipe(
           Effect.provide(CliLayers),
           Effect.catch((err: unknown) =>
-            Effect.sync(() => {
+            Effect.promise(async () => {
               appendBootstrapLog(`\n[ERROR] ${formatUnknownError(err)}\n`);
               console.error(err);
               process.exit(1);

--- a/dot/src/lib/omarchyHost.ts
+++ b/dot/src/lib/omarchyHost.ts
@@ -250,32 +250,48 @@ export const ensureHyprConfigLink = (
 
     const linkContent = stowLinkContent(home, linkPath, sourceFile);
 
-    try {
-      const stat = lstatSync(linkPath);
-      if (stat.isSymbolicLink() && readlinkSync(linkPath) === linkContent) {
-        return;
-      }
-    } catch (error) {
-      if (!isMissingLinkError(error)) {
-        yield* log.warn(
-          `Skipping Hypr config link repair (could not inspect ${displayPath(linkPath)})`,
-        );
-        return;
-      }
+    const currentLink = inspectLink(linkPath, linkContent);
+    if (currentLink.type === "matching") return;
+    if (currentLink.type === "unreadable") {
+      yield* log.warn(
+        `Skipping Hypr config link repair (could not inspect ${displayPath(linkPath)})`,
+      );
+      return;
     }
 
     const tmpLink = `${linkPath}.dot-${process.pid}`;
-    try {
-      unlinkSync(tmpLink);
-    } catch {
-      // No stale temp link to clear.
-    }
+    removeIfPresent(tmpLink);
     symlinkSync(linkContent, tmpLink);
     renameSync(tmpLink, linkPath);
     yield* log.info(
       `Repaired Hypr config link (${displayPath(linkPath)} -> hyprland.conf)`,
     );
   });
+
+function inspectLink(
+  linkPath: string,
+  expectedContent: string,
+): { readonly type: "matching" | "different" | "missing" | "unreadable" } {
+  try {
+    const stat = lstatSync(linkPath);
+    if (stat.isSymbolicLink() && readlinkSync(linkPath) === expectedContent) {
+      return { type: "matching" };
+    }
+    return { type: "different" };
+  } catch (error) {
+    return isMissingLinkError(error)
+      ? { type: "missing" }
+      : { type: "unreadable" };
+  }
+}
+
+function removeIfPresent(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // No stale temp link to clear.
+  }
+}
 
 /** Create or repair the host-selected Hypr config symlink used by one-branch config. */
 export const ensureHyprHostLink = (

--- a/dot/src/lib/selfUpdate.ts
+++ b/dot/src/lib/selfUpdate.ts
@@ -74,8 +74,6 @@ export const restartDot = (
     log(`Restarting: ${command}`);
     const exitCode = yield* executor.inherit(BIN_PATH, args);
     if (exitCode !== 0) {
-      return yield* Effect.fail(
-        new CommandError({ command, exitCode, stderr: "" }),
-      );
+      return yield* new CommandError({ command, exitCode, stderr: "" });
     }
   });

--- a/dot/src/lib/skillUpdates.ts
+++ b/dot/src/lib/skillUpdates.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { readdirSync, existsSync, readFileSync, mkdirSync } from "fs";
 import { writeFileSync, unlinkSync } from "fs";
 import { join, basename, dirname, relative } from "path";
@@ -16,6 +16,13 @@ export interface SkillOrigin {
   readonly branch: string;
   readonly path: string;
 }
+
+class SkillUpdateError extends Schema.TaggedErrorClass<SkillUpdateError>()(
+  "SkillUpdateError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 /** Parsed SKILL.md frontmatter metadata */
 export interface SkillMeta {
@@ -323,9 +330,9 @@ export const fetchFile = (origin: SkillOrigin, filePath: string) =>
     const base64Content = yield* ghApi(endpoint, ".content");
 
     if (!base64Content) {
-      return yield* Effect.fail(
-        new Error(`Empty content returned from gh api ${endpoint}`),
-      );
+      return yield* new SkillUpdateError({
+        message: `Empty content returned from gh api ${endpoint}`,
+      });
     }
 
     // Decode base64 (GitHub returns content with newlines embedded)

--- a/dot/src/mcp/commands/McpSync.ts
+++ b/dot/src/mcp/commands/McpSync.ts
@@ -8,7 +8,7 @@
  * in the sync adapters; this orchestrator owns IO and logging, mirroring
  * {@link file://./../../commands/AgentsSync.ts}.
  */
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import {
   existsSync,
   mkdirSync,
@@ -40,6 +40,13 @@ const HARNESS_RELATIVE_PATH: Record<McpHarness, string> = {
   vscode: join("agents", ".config", "Code", "User", "mcp.json"),
   copilot: join("agents", ".copilot", "mcp-config.json"),
 };
+
+class McpSyncError extends Schema.TaggedErrorClass<McpSyncError>()(
+  "McpSyncError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 /** Atomic JSON write: mkdir -p, write to temp, rename over destination. */
 function atomicWriteJson(dest: string, value: unknown): void {
@@ -122,9 +129,9 @@ export const mcpSync = Effect.gen(function* () {
     for (const diagnostic of mcpConfig.diagnostics) {
       yield* log.error(`  ${diagnostic}`);
     }
-    return yield* Effect.fail(
-      new Error(`Invalid MCP spec: ${displayPath(mcpConfig.filePath)}`),
-    );
+    return yield* new McpSyncError({
+      message: `Invalid MCP spec: ${displayPath(mcpConfig.filePath)}`,
+    });
   }
 
   const spec = mcpConfig.spec;

--- a/dot/src/notes/commands/Handoffs.ts
+++ b/dot/src/notes/commands/Handoffs.ts
@@ -60,7 +60,7 @@ export function handoffsList(all: boolean) {
     }
   }).pipe(
     Effect.catch((error) =>
-      Effect.sync(() => {
+      Effect.promise(async () => {
         const message =
           error instanceof NotesError ? error.message : String(error);
         console.error(`[dot handoffs] ${message}`);

--- a/dot/src/notes/commands/Notes.ts
+++ b/dot/src/notes/commands/Notes.ts
@@ -49,7 +49,7 @@ Examples:
 }
 
 function invalid(message: string, usage: string): Effect.Effect<void> {
-  return Effect.sync(() => {
+  return Effect.promise(async () => {
     exitWithError([message, usage]);
   });
 }
@@ -57,7 +57,7 @@ function invalid(message: string, usage: string): Effect.Effect<void> {
 function handleNotesError<R>(effect: Effect.Effect<void, NotesError, R>) {
   return effect.pipe(
     Effect.catch((error) =>
-      Effect.sync(() => {
+      Effect.promise(async () => {
         exitWithError(
           error.detail
             ? [`[dot notes] ${error.message}`, error.detail]

--- a/dot/src/notes/services/Notes.ts
+++ b/dot/src/notes/services/Notes.ts
@@ -277,6 +277,18 @@ function listNoteEntries(
     .sort((a, b) => b.mtime - a.mtime);
 }
 
+function listNoteEntriesSafe(
+  notesPath: string,
+):
+  | { readonly ok: true; readonly entries: readonly NoteEntry[] }
+  | { readonly ok: false; readonly error: string } {
+  try {
+    return { ok: true, entries: listNoteEntries(notesPath) };
+  } catch (error) {
+    return { ok: false, error: errorMessage(error) };
+  }
+}
+
 function sortedDirectories(path: string) {
   return readdirSync(path, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -539,11 +551,9 @@ export class Notes extends Context.Service<Notes, NotesService>()("Notes") {
           "--is-inside-work-tree",
         ]);
         if (!inRepo.ok || inRepo.text !== "true") {
-          return yield* Effect.fail(
-            fail(
-              "RepoNotesPlugin: not inside a git worktree — cannot resolve owner/repo.",
-              inRepo.ok ? undefined : inRepo.error,
-            ),
+          return yield* fail(
+            "RepoNotesPlugin: not inside a git worktree — cannot resolve owner/repo.",
+            inRepo.ok ? undefined : inRepo.error,
           );
         }
 
@@ -573,20 +583,16 @@ export class Notes extends Context.Service<Notes, NotesService>()("Notes") {
         ]);
 
         if (!remoteUrl.ok) {
-          return yield* Effect.fail(
-            fail(
-              `RepoNotesPlugin: unable to read URL for remote "${remote}".`,
-              remoteUrl.error,
-            ),
+          return yield* fail(
+            `RepoNotesPlugin: unable to read URL for remote "${remote}".`,
+            remoteUrl.error,
           );
         }
 
         const parsed = parseRemoteUrl(remoteUrl.text);
         if (!parsed) {
-          return yield* Effect.fail(
-            fail(
-              `RepoNotesPlugin: could not parse owner/repo from remote URL: ${remoteUrl.text}`,
-            ),
+          return yield* fail(
+            `RepoNotesPlugin: could not parse owner/repo from remote URL: ${remoteUrl.text}`,
           );
         }
 
@@ -745,11 +751,12 @@ export class Notes extends Context.Service<Notes, NotesService>()("Notes") {
             const warnings = [...resolved.warnings];
             let entries: readonly NoteEntry[] = [];
             if (COMMANDS_NEEDING_LIST.has(command)) {
-              try {
-                entries = listNoteEntries(notesPath);
-              } catch (error) {
+              const listedEntries = listNoteEntriesSafe(notesPath);
+              if (listedEntries.ok) {
+                entries = listedEntries.entries;
+              } else {
                 warnings.push(
-                  `Unable to list existing notes: ${errorMessage(error)}`,
+                  `Unable to list existing notes: ${listedEntries.error}`,
                 );
               }
             }
@@ -951,10 +958,8 @@ export class Notes extends Context.Service<Notes, NotesService>()("Notes") {
 
             const updated = setFrontmatterPriority(content, priority);
             if (updated === null) {
-              return yield* Effect.fail(
-                fail(
-                  `setPriority: no frontmatter found in ${filePath}; cannot set priority`,
-                ),
+              return yield* fail(
+                `setPriority: no frontmatter found in ${filePath}; cannot set priority`,
               );
             }
 

--- a/dot/src/services/Launcher.ts
+++ b/dot/src/services/Launcher.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Stream } from "effect";
+import { Context, Effect, Layer, Schema, Stream } from "effect";
 import type { CliRenderer } from "@opentui/core";
 import { CommandExecutor, CommandError } from "./CommandExecutor.js";
 import { OutputLog } from "./OutputLog.js";
@@ -11,13 +11,13 @@ const log = (msg: string) => {
 };
 
 /** Domain error for launcher operations */
-export class LauncherError {
-  readonly _tag = "LauncherError";
-  constructor(
-    readonly message: string,
-    readonly exitCode?: number,
-  ) {}
-}
+export class LauncherError extends Schema.TaggedErrorClass<LauncherError>()(
+  "LauncherError",
+  {
+    message: Schema.String,
+    exitCode: Schema.optional(Schema.Number),
+  },
+) {}
 
 /** Service interface for high-level command execution with output routing */
 export interface LauncherService {
@@ -79,9 +79,10 @@ export class Launcher extends Context.Service<Launcher, LauncherService>()(
                 }
 
                 if (exitCode !== 0) {
-                  return yield* Effect.fail(
-                    new LauncherError(`Command failed: ${cmd}`, exitCode),
-                  );
+                  return yield* new LauncherError({
+                    message: `Command failed: ${cmd}`,
+                    exitCode,
+                  });
                 }
               } finally {
                 renderer.currentRenderBuffer.clear();
@@ -115,18 +116,16 @@ export class Launcher extends Context.Service<Launcher, LauncherService>()(
           silent: (cmd) =>
             Effect.gen(function* () {
               log(`Silent: ${cmd}`);
-              return yield* executor
-                .run("bash", ["-c", cmd])
-                .pipe(
-                  Effect.catchTag("CommandError", (err: CommandError) =>
-                    Effect.fail(
-                      new LauncherError(
-                        `Command failed: ${cmd}\n${err.stderr}`,
-                        err.exitCode,
-                      ),
-                    ),
+              return yield* executor.run("bash", ["-c", cmd]).pipe(
+                Effect.catchTag("CommandError", (err: CommandError) =>
+                  Effect.fail(
+                    new LauncherError({
+                      message: `Command failed: ${cmd}\n${err.stderr}`,
+                      exitCode: err.exitCode,
+                    }),
                   ),
-                );
+                ),
+              );
             }),
         };
       }),
@@ -149,9 +148,10 @@ export class Launcher extends Context.Service<Launcher, LauncherService>()(
             log(`Running (CLI): ${cmd}`);
             const exitCode = yield* executor.inherit("bash", ["-c", cmd]);
             if (exitCode !== 0) {
-              return yield* Effect.fail(
-                new LauncherError(`Command failed: ${cmd}`, exitCode),
-              );
+              return yield* new LauncherError({
+                message: `Command failed: ${cmd}`,
+                exitCode,
+              });
             }
           }),
 
@@ -179,18 +179,16 @@ export class Launcher extends Context.Service<Launcher, LauncherService>()(
         silent: (cmd) =>
           Effect.gen(function* () {
             log(`Silent (CLI): ${cmd}`);
-            return yield* executor
-              .run("bash", ["-c", cmd])
-              .pipe(
-                Effect.catchTag("CommandError", (err: CommandError) =>
-                  Effect.fail(
-                    new LauncherError(
-                      `Command failed: ${cmd}\n${err.stderr}`,
-                      err.exitCode,
-                    ),
-                  ),
+            return yield* executor.run("bash", ["-c", cmd]).pipe(
+              Effect.catchTag("CommandError", (err: CommandError) =>
+                Effect.fail(
+                  new LauncherError({
+                    message: `Command failed: ${cmd}\n${err.stderr}`,
+                    exitCode: err.exitCode,
+                  }),
                 ),
-              );
+              ),
+            );
           }),
       };
     }),

--- a/dot/src/services/ModelDiscovery.ts
+++ b/dot/src/services/ModelDiscovery.ts
@@ -148,4 +148,4 @@ export const discoverFastModel: Effect.Effect<
     log(`Model discovery failed: ${msg}`);
     return undefined;
   },
-}).pipe(Effect.catch(() => Effect.succeed(undefined)));
+}).pipe(Effect.catch(() => Effect.void.pipe(Effect.as(undefined))));

--- a/dot/src/services/OutputLog.ts
+++ b/dot/src/services/OutputLog.ts
@@ -1,4 +1,12 @@
-import { Context, Effect, Layer, PubSub, Schedule, Stream } from "effect";
+import {
+  Clock,
+  Context,
+  Effect,
+  Layer,
+  PubSub,
+  Schedule,
+  Stream,
+} from "effect";
 import {
   appendFileSync,
   mkdirSync,
@@ -203,7 +211,7 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
       const entries: LogEntry[] = [];
       const defaultLogFile = join(
         config.logDir,
-        `${new Date().toISOString().replace(/[:.]/g, "-")}.log`,
+        `${new Date(yield* Clock.currentTimeMillis).toISOString().replace(/[:.]/g, "-")}.log`,
       );
       const paths = logFiles(defaultLogFile);
 
@@ -220,7 +228,11 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
       const emit = (level: LogLevel, message: string): Effect.Effect<void> =>
         Effect.gen(function* () {
           ensureInitialised();
-          const entry: LogEntry = { level, message, timestamp: Date.now() };
+          const entry: LogEntry = {
+            level,
+            message,
+            timestamp: yield* Clock.currentTimeMillis,
+          };
           entries.push(entry);
           appendLogFiles(paths, entry);
           yield* PubSub.publish(pubsub, entry);
@@ -237,11 +249,12 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
         // still log the duration on completion to match the CLI contract.
         withSpinner: (label, effect) =>
           Effect.gen(function* () {
-            const startedAt = Date.now();
+            const startedAt = yield* Clock.currentTimeMillis;
             const result = yield* effect;
+            const finishedAt = yield* Clock.currentTimeMillis;
             yield* emit(
               "info",
-              `${label} (${formatDuration(Date.now() - startedAt)})`,
+              `${label} (${formatDuration(finishedAt - startedAt)})`,
             );
             return result;
           }),
@@ -260,7 +273,7 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
       const entries: LogEntry[] = [];
       const defaultLogFile = join(
         config.logDir,
-        `${new Date().toISOString().replace(/[:.]/g, "-")}.log`,
+        `${new Date(yield* Clock.currentTimeMillis).toISOString().replace(/[:.]/g, "-")}.log`,
       );
       const paths = logFiles(defaultLogFile);
 
@@ -283,10 +296,10 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
         startedAt: number;
       } | null = null;
 
-      const renderSpinner = (): void => {
+      const renderSpinner = (now: number): void => {
         if (!spinner) return;
         const frame = SPINNER_FRAMES[spinner.frame % SPINNER_FRAMES.length]!;
-        const seconds = Math.floor((Date.now() - spinner.startedAt) / 1000);
+        const seconds = Math.floor((now - spinner.startedAt) / 1000);
         const elapsedText = seconds >= 1 ? ` (${seconds}s)` : "";
         // Keep the whole spinner on one physical row. A wrapped line breaks the
         // in-place CLEAR_LINE redraw (it only clears the last row) and leaves a
@@ -307,22 +320,24 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
       };
 
       const emit = (level: LogLevel, message: string): Effect.Effect<void> =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
           ensureInitialised();
-          const entry: LogEntry = { level, message, timestamp: Date.now() };
+          const entry: LogEntry = { level, message, timestamp: now };
           entries.push(entry);
           appendLogFiles(paths, entry);
           // Clear the spinner line before a real log line, then redraw it
           // beneath so the spinner stays pinned to the bottom.
           if (spinner) process.stdout.write(CLEAR_LINE);
           process.stdout.write(formatAnsi(entry) + "\n");
-          if (spinner) renderSpinner();
+          if (spinner) renderSpinner(now);
         });
 
-      const tick = Effect.sync(() => {
+      const tick = Effect.gen(function* () {
         if (!spinner) return;
+        const now = yield* Clock.currentTimeMillis;
         spinner.frame += 1;
-        renderSpinner();
+        renderSpinner(now);
       });
 
       const runSpinner = <A, E, R>(
@@ -333,10 +348,11 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
         Effect.scoped(
           Effect.gen(function* () {
             yield* Effect.acquireRelease(
-              Effect.sync(() => {
+              Effect.gen(function* () {
+                const now = yield* Clock.currentTimeMillis;
                 spinner = { label, frame: 0, startedAt };
                 process.stdout.write(HIDE_CURSOR);
-                renderSpinner();
+                renderSpinner(now);
               }),
               () =>
                 Effect.sync(() => {
@@ -357,14 +373,15 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
         effect: Effect.Effect<A, E, R>,
       ): Effect.Effect<A, E, R> =>
         Effect.gen(function* () {
-          const startedAt = Date.now();
+          const startedAt = yield* Clock.currentTimeMillis;
           // Animate only on a TTY; the duration line is logged either way.
           const result = yield* spinnerEnabled
             ? runSpinner(label, startedAt, effect)
             : effect;
+          const finishedAt = yield* Clock.currentTimeMillis;
           yield* emit(
             "info",
-            `${label} (${formatDuration(Date.now() - startedAt)})`,
+            `${label} (${formatDuration(finishedAt - startedAt)})`,
           );
           return result;
         });
@@ -378,10 +395,11 @@ export class OutputLog extends Context.Service<OutputLog, OutputLogService>()(
         flush: Effect.sync(() => entries.map(formatPlain).join("\n")),
         withSpinner,
         updateSpinner: (label) =>
-          Effect.sync(() => {
+          Effect.gen(function* () {
             if (!spinner) return;
+            const now = yield* Clock.currentTimeMillis;
             spinner.label = label;
-            renderSpinner();
+            renderSpinner(now);
           }),
       };
     }),

--- a/dot/src/theme.ts
+++ b/dot/src/theme.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { CONFIG_DIR } from "./lib/paths.js";
@@ -156,6 +156,13 @@ function deriveTheme(c: Record<string, string>): Theme {
 
 // --- Theme loading ---
 
+class ThemeLoadError extends Schema.TaggedErrorClass<ThemeLoadError>()(
+  "ThemeLoadError",
+  {
+    message: Schema.String,
+  },
+) {}
+
 /**
  * Load the active Omarchy theme from `colors.toml` and derive semantic TUI tokens.
  *
@@ -169,8 +176,7 @@ function deriveTheme(c: Record<string, string>): Theme {
 export const loadTheme: Effect.Effect<Theme> = Effect.gen(function* () {
   const raw = yield* Effect.try({
     try: () => readFileSync(COLORS_TOML_PATH, "utf-8"),
-    catch: (error) =>
-      error instanceof Error ? error : new Error(String(error)),
+    catch: (error) => new ThemeLoadError({ message: String(error) }),
   });
   return deriveTheme(parseColorsToml(raw));
 }).pipe(Effect.orElseSucceed(() => FALLBACK));

--- a/dot/src/tui/hyprland.ts
+++ b/dot/src/tui/hyprland.ts
@@ -28,7 +28,10 @@ export const resizeIfFloating = (
       stderr: "ignore",
     });
     const text = yield* Effect.promise(() => new Response(proc.stdout).text());
-    const win = JSON.parse(text) as { floating?: boolean };
+    const win = yield* Effect.try({
+      try: () => JSON.parse(text) as { floating?: boolean },
+      catch: () => undefined,
+    });
     if (win.floating) {
       Bun.spawn(
         [

--- a/dot/tsconfig.json
+++ b/dot/tsconfig.json
@@ -9,9 +9,12 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["bun-types"],
+    "types": ["bun"],
     "plugins": [
-      { "name": "@effect/language-service", "ignoreEffectWarningsInTscExitCode": true }
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectWarningsInTscExitCode": true
+      }
     ]
   },
   "include": ["src"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Convert launcher, dashboard, git-commit, workflow, and commit-view failures to tagged Effect errors.
- Use Effect `Clock.currentTimeMillis` in service timing paths and pass injectable time into relative git-context formatting.
- Bridge TUI callbacks with `Effect.runForkWith` / `Effect.runPromiseWith` so callbacks retain the surrounding Effect context.
- Clear Effect language-service typecheck diagnostics by replacing dead catches, lazy promise sync wrappers, plain `Error` channels, and generator-local try/catch blocks.
- Align `tsconfig.json` with the declared Bun type package.

### Validation
- `bunx tsc --noEmit` (clean output)
- `bun run format`
- `bun run format:check`
- `bun test`
- `bun run build`
- `../scripts/.local/bin/dot help`
- `../scripts/.local/bin/dot git-commit --help`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee7199ff-9c64-4f40-99b8-332191ef7c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee7199ff-9c64-4f40-99b8-332191ef7c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

