### PR TITLE
Use generic agent harness wording in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Keep shared cross-project agent behaviour in the global `~/.config/opencode/AGEN
 - `agents/.config/opencode/` contains the shared OpenCode config source published from this repo.
 - `agents/.agents/skills/` contains globally stowed skills shared by OpenCode and Codex via `~/.agents/skills/`.
 - `.opencode/skills/` contains repo-local skills for this repo only.
-- `dot agents-sync` mirrors the global private AGENTS source into Cursor, Claude Code, and Codex instruction files; `dot update` and `dot init` run that sync automatically.
+- `dot agents-sync` mirrors the global private AGENTS source into agent harness instruction files; `dot update` and `dot init` run that sync automatically.
 
 ### OpenCode Layer Boundaries
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #94 review feedback on [AGENTS.md line 38](https://github.com/timmo001/dotfiles/pull/94/changes#r3523364244).

## Change

Replace the enumerated harness list (`Cursor`, `Claude Code`, `Codex`) with generic wording (`agent harness instruction files`) so `AGENTS.md` does not go stale as supported harnesses change.

## Validation

- Single-line documentation edit; no code or generated docs affected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-854bca88-0b45-4072-8cc3-2cc4c8e52e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-854bca88-0b45-4072-8cc3-2cc4c8e52e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

