### PR TITLE
Fix missing JSDoc and CLI spec formatting drift

### DIFF
--- a/dot/src/cli/spec.ts
+++ b/dot/src/cli/spec.ts
@@ -810,8 +810,7 @@ export const cliCommands: readonly CliCommandSpec[] = [
   },
   {
     name: "agents-sync",
-    summary:
-      "Mirror AGENTS.md to agent harness instruction files",
+    summary: "Mirror AGENTS.md to agent harness instruction files",
     options: [helpOption],
   },
   {

--- a/dot/src/lib/initState.ts
+++ b/dot/src/lib/initState.ts
@@ -12,7 +12,9 @@ class InitStateError extends Schema.TaggedErrorClass<InitStateError>()(
   },
 ) {}
 
+/** What triggered writing the first-use setup complete marker. */
 type InitCompleteSource = "init" | "update";
+/** Outcome of ensuring the first-use setup complete marker exists. */
 export type InitCompleteMarkerStatus = "created" | "exists" | "in-progress";
 
 /** Return the complete marker path for first-use setup state. */

--- a/dot/src/tui/App.ts
+++ b/dot/src/tui/App.ts
@@ -76,6 +76,7 @@ const formatDiffTitle = (changedCount: number): string =>
 /** Wrap a string in single quotes, escaping embedded single quotes for safe shell interpolation */
 const shellQuote = (s: string): string => `'${s.replace(/'/g, "'\\''")}'`;
 
+/** Startup options controlling the App's initial view and pre-selected action */
 export interface AppOptions {
   /** Which view to start on (default: "main") */
   readonly initialView?: ViewId;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the repo's documentation surface and fixed the concrete gaps found. The docs site (generated `dot/commands.md` and OpenCode `reference/*.md`, hand-written pages, environment variables) was already in sync, so the only genuine gaps were in the JSDoc that `dot/AGENTS.md` mandates for exported symbols (CI does not enforce it).

## Changes

- Add interface-level JSDoc to `AppOptions` in `dot/src/tui/App.ts` (every sibling interface, including `AppDeps`, already carries one).
- Add JSDoc to the exported `InitCompleteMarkerStatus` type (and its private `InitCompleteSource` companion) in `dot/src/lib/initState.ts`, matching the surrounding documented declarations.
- Reformat `dot/src/cli/spec.ts` with the pinned prettier (`3.9.4` in `pnpm-lock.yaml`); the committed file wrapped a `summary` line under an older prettier and currently fails `dot:format:check` on the base branch. Content is unchanged, so the generated command reference is unaffected.

## Audit performed

- `mise run docs:gen` — no drift in generated `commands.md` / `reference/*.md`.
- Cross-checked the CLI spec, hand-written docs pages, and the `ENV` registry against `configuration/environment.md` — all commands, flags, and tunable variables documented.
- Scanned `dot/src` for exported declarations and data-model interfaces missing JSDoc; the only convention-consistent gaps were the two fixed here (member-level omissions on plain data interfaces are the codebase's deliberate convention and were left as-is).

## Testing

- `mise run dot:check` (typecheck + prettier) passes.
- `mise run dot:build` compiles the binary.
- `mise run docs:gen` produces no drift.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c73cf465-e621-4e7a-bf09-ac067a8be8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c73cf465-e621-4e7a-bf09-ac067a8be8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

