### PR TITLE
Remove vestigial pnpm-workspace.yaml so the project is bun/mise-only

### DIFF
--- a/dot/pnpm-workspace.yaml
+++ b/dot/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
----
-allowBuilds:
-  msgpackr-extract: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the repo for `pnpm` mentions and confirmed the project is already standardised on **mise + bun** via the root `mise.toml`. The one real remnant contradicting that was `dot/pnpm-workspace.yaml`, a tracked pnpm-only config file. This PR removes it.

## What was checked

- Root `mise.toml` already pins the toolchain (`node`, `bun`) and defines every dev task (`dot:*`, `docs:*`). No change needed.
- Both JS/TS packages track `bun.lock` (`dot/bun.lock`, `docs/bun.lock`); CI (`tui-build.yml`) runs `bun install --frozen-lockfile`.
- `AGENTS.md` and `dot/AGENTS.md` already document bun as the sole package manager and `bun.lock` as the tracked lockfile.

## The change

- Deleted `dot/pnpm-workspace.yaml` (only held `allowBuilds: msgpackr-extract: false`). Bun does not run dependency build scripts unless listed in `trustedDependencies`, and `dot/package.json` lists none — so bun already skips the `msgpackr-extract` native build, matching the old pnpm intent. Removal is behaviour-preserving.

## Left intentionally unchanged

These `pnpm` mentions are legitimate and not this project's package manager:
- `agents/.agents/skills/fallow/**` — docs for the external `fallow` tool's pnpm-workspace/catalog features.
- `mise/.config/mise/config.toml` (`npm:pnpm`), plus docs/`topgrade.toml`/`dependencies.ts` mentions — describe pnpm as a globally mise-managed tool, not this project's manager.
- `zsh/.zshrc` `dev()` — a generic multi-manager project launcher for the user's other projects.
- `pitchfork-dev-server-guard.ts` and `dot/src/lib/skillCheck.ts` ignore-term list — generic references.

## Testing

- `bun install --frozen-lockfile` (in `dot/`, bun 1.3.14 = mise-pinned) — passes without the pnpm file; `msgpackr-extract` build not run.
- `bunx tsc --noEmit` — passes.
- `bun run build` — compiles the `dot` binary successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a34a1a9-ac6f-4bac-a48c-ff273ef20b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a34a1a9-ac6f-4bac-a48c-ff273ef20b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

