### PR TITLE
Fix TypeScript 7 upgrade for Effect language service

### DIFF
--- a/dot/.vscode/settings.json
+++ b/dot/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.native-preview.tsdk": "node_modules/typescript",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/dot/AGENTS.md
+++ b/dot/AGENTS.md
@@ -299,7 +299,7 @@ For dead-code analysis, use the MCP `analyze` tool with `root: dot`, or `/fallow
 
 ### Effect language service
 
-`@effect/language-service` is enabled in `tsconfig.json`, and the `prepare` script patches the local TypeScript (`effect-language-service patch`) so `mise run dot:typecheck` surfaces the official Effect v4 diagnostics inline. Effect errors fail the typecheck; warnings and messages stay advisory (`ignoreEffectWarningsInTscExitCode` is set), so keep them visible but non-blocking. Editors and OpenCode also pick up the plugin's refactors and diagnostics through the TypeScript LSP when the workspace TypeScript version is used. For a report without patching, run `effect-language-service diagnostics --project tsconfig.json` (also `overview`, `quickfixes`, `layerinfo`) from `dot/`, always via the local install rather than a bare remote `bunx`/`npx`.
+`@effect/tsgo` patches the TypeScript 7 native binary (`effect-tsgo patch` in `prepare`) so `mise run dot:typecheck` surfaces the official Effect v4 diagnostics inline. The plugin entry in `tsconfig.json` remains named `@effect/language-service` (Effect's stable plugin id). Effect errors fail the typecheck; warnings and messages stay advisory (`ignoreEffectWarningsInTscExitCode` is set), so keep them visible but non-blocking. Editors pick up the diagnostics through the TypeScript Native Preview language server when `typescript.native-preview.tsdk` points at the workspace `typescript` install.
 
 Dependency note: the tracked lockfile is `bun.lock` (committed, matching the `docs/` package). CI runs `bun install --frozen-lockfile` against it. After changing dependencies with `bun add`/`bun update`, commit the regenerated `bun.lock`, otherwise the CI frozen install fails.
 

--- a/dot/bun.lock
+++ b/dot/bun.lock
@@ -12,7 +12,7 @@
         "fuse.js": "^7.3.0",
       },
       "devDependencies": {
-        "@effect/language-service": "^0.86.4",
+        "@effect/tsgo": "^0.16.3",
         "@types/bun": "^1.3.13",
         "prettier": "^3.5.3",
         "typescript": "^7.0.0",
@@ -20,11 +20,25 @@
     },
   },
   "packages": {
-    "@effect/language-service": ["@effect/language-service@0.86.4", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-XzAPsbwCdm0gRh0E8wJu3wXECb00QraE3LnbObA4RgHn8u2TEbwAjmBadRnwSgOIElfzZjbsRqNR706/V54hDg=="],
-
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.93", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.93", "mime": "^4.1.0", "undici": "^8.2.0" }, "peerDependencies": { "effect": "^4.0.0-beta.93", "ioredis": "^5.7.0" } }, "sha512-QagsCGR0ZOXaCQqS5qGR2mcDng4LiP2bYhiiX1D6UC8cT9vsusVVOHiJWn8CupeDx+yVnPcu81QmA/SDt6GM1w=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.93", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.93" } }, "sha512-XUqZ2u5GglBqY8q2jj4Q7GjN5K/enedk8auZM9rY/l5a/myaQTrQp3QnvpIK4/Yg0WFjLGuctGPMKWRk3OLIrA=="],
+
+    "@effect/tsgo": ["@effect/tsgo@0.16.3", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.16.3", "@effect/tsgo-darwin-x64": "0.16.3", "@effect/tsgo-linux-arm": "0.16.3", "@effect/tsgo-linux-arm64": "0.16.3", "@effect/tsgo-linux-x64": "0.16.3", "@effect/tsgo-win32-arm64": "0.16.3", "@effect/tsgo-win32-x64": "0.16.3" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-tCmYzU9E6VPXSNKTrMNPkmLWG6UYWkNcfWLNt5qW+HuP7RNWnprbXuHdhTM5nwAyL8nA137g8X6+0rPzaBJX+g=="],
+
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.16.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-k3f8LzSDzPMGveMuChvWjlOxgfCsr+b/Lzo8NkUqIiIyDM2Rmi3vSGk8xgSxLzqoS/Z5dl9Y4CS6LGZlEr6Ssg=="],
+
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.16.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fbqrNoDSRGolimV2aU0Ix/qsj/RADTyTUTWtucPJCzKt/zT6VAZkcGJYwGVshvacdektxBHMB7Cy0YZIh5s9ng=="],
+
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.16.3", "", { "os": "linux", "cpu": "arm" }, "sha512-uTROMiIX33USQjB6qLYSxZfCmEwpD5vG9PfQk61e/ehCbfLDNI3XcaGgzuc2UeATyphpbpCa+kqgceumsxCZRg=="],
+
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.16.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-GbtT278MB84GorsGar3yv8EdjEJIqEPmYr0kKsr8J0rTx3pL0MA0NDN2CcOcC4Ijxjo6f0tdmNIBuTclz37XGQ=="],
+
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.16.3", "", { "os": "linux", "cpu": "x64" }, "sha512-IsGBQVY8CPynmtCpFH6WcydNN7rMtFi4eWn6npZnYnzGYUHXiES0G/w8V1QKC+7uvxmLfLsivxD3E9sAOmDDGA=="],
+
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.16.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-YrNgXA/zmv65VfNPSDiKDOSd6INy8sAtpoX+uVN315ssEqcbHUmnuUcAFDSf2I7bjmU52Jg975M7M+AK2YMrVA=="],
+
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.16.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UvNmGT3Dt0mfJ372SHZbRKM07q286iKpX9VeF1qI1HM6+gaONwfysmewYLv14HXRsJEN089OPe9xJee/Saxbhw=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 

--- a/dot/package.json
+++ b/dot/package.json
@@ -8,7 +8,7 @@
     "build": "bun build src/index.ts --compile --outfile ../scripts/.local/bin/dot",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
-    "prepare": "effect-language-service patch"
+    "prepare": "effect-tsgo patch"
   },
   "dependencies": {
     "@effect/platform-node": "^4.0.0-beta.93",
@@ -18,7 +18,7 @@
     "fuse.js": "^7.3.0"
   },
   "devDependencies": {
-    "@effect/language-service": "^0.86.4",
+    "@effect/tsgo": "^0.16.3",
     "@types/bun": "^1.3.13",
     "prettier": "^3.5.3",
     "typescript": "^7.0.0"

--- a/dot/tsconfig.json
+++ b/dot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@effect/language-service/schema.json",
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json",
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing `Build dot` check on Renovate PR #117 (`Update dependency typescript to v7`).

TypeScript 7 ships the native Go compiler and no longer provides `typescript/lib/typescript.js`, so `effect-language-service patch` fails during `bun install --frozen-lockfile`.

## Changes

- Keep the TypeScript `^7.0.0` bump from #117
- Replace `@effect/language-service` with `@effect/tsgo`
- Switch `prepare` from `effect-language-service patch` to `effect-tsgo patch`
- Point `tsconfig.json` `$schema` at the Effect-TS/tsgo schema URL
- Update `dot/.vscode/settings.json` for the TypeScript Native Preview tsdk path
- Update `dot/AGENTS.md` Effect language-service guidance

## Validation

- `bun install --frozen-lockfile` succeeds (prepare patch verifies)
- `mise run dot:typecheck` exits 0 (Effect suggestions only; non-blocking)
- `mise run dot:format:check` passes
- `mise run dot:build` compiles the binary

Supersedes / unblocks https://github.com/timmo001/dotfiles/pull/117.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fba473be-4b8b-45ab-baae-9da83efdc39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fba473be-4b8b-45ab-baae-9da83efdc39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

